### PR TITLE
feat: report per-core CPU temperatures

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -196,10 +196,6 @@
       background-color: green;
       transition: width 0.5s ease, background-color 0.5s ease;
     }
-    #tempValue {
-      font-size: 1.2rem;
-      font-weight: bold;
-    }
     .badge {
       padding: 4px 10px;
       border-radius: 8px;
@@ -378,13 +374,8 @@
   <h2>Utilisation CPU par cœur <span id="cpuLoadBadge" class="badge">--</span></h2>
   <canvas id="cpuChart"></canvas>
 
-  <h2>Température CPU</h2>
-  <div class="temp-wrapper">
-    <span id="tempValue">-- °C</span>
-    <div class="temp-bar">
-      <div id="tempFill" class="temp-fill"></div>
-    </div>
-  </div>
+  <h2>Températures CPU</h2>
+  <div id="tempsContainer"></div>
 
   <h2>Mémoire RAM</h2>
   <div class="memory-container">

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -105,15 +105,37 @@ function renderText(json) {
     disksContainer.innerHTML = "<p>Aucun disque détecté.</p>";
   }
 
-  const temp = parseFloat(json.temperature);
-  document.getElementById("tempValue").textContent = temp.toFixed(1) + "°C";
-  const fill = document.getElementById("tempFill");
-  const percentage = Math.min(100, Math.max(0, temp));
-  fill.style.width = percentage + "%";
-  fill.classList.remove("green", "orange", "red");
-  if (temp < 50) fill.classList.add("green");
-  else if (temp < 70) fill.classList.add("orange");
-  else fill.classList.add("red");
+  const tempsContainer = document.getElementById("tempsContainer");
+  tempsContainer.innerHTML = "";
+  const temps = json.cpu?.temperatures;
+  if (Array.isArray(temps) && temps.length > 0) {
+    temps.forEach(t => {
+      const value = parseFloat(t.temp);
+      const wrapper = document.createElement("div");
+      wrapper.className = "temp-wrapper";
+
+      const label = document.createElement("span");
+      label.textContent = `Core ${t.core}: ${isNaN(value) ? "N/A" : value.toFixed(1) + "°C"}`;
+      wrapper.appendChild(label);
+
+      const bar = document.createElement("div");
+      bar.className = "temp-bar";
+      const fill = document.createElement("div");
+      fill.className = "temp-fill";
+      if (!isNaN(value)) {
+        const percentage = Math.min(100, Math.max(0, value));
+        fill.style.width = percentage + "%";
+        if (value < 50) fill.classList.add("green");
+        else if (value < 70) fill.classList.add("orange");
+        else fill.classList.add("red");
+      }
+      bar.appendChild(fill);
+      wrapper.appendChild(bar);
+      tempsContainer.appendChild(wrapper);
+    });
+  } else {
+    tempsContainer.textContent = "N/A";
+  }
 
   const badge = document.getElementById('cpuLoadBadge');
   const color = json.cpu_load_color ? json.cpu_load_color.toLowerCase() : "";

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -37,8 +37,16 @@ CPU_CORES=$(nproc)
 CPU_USAGE_PER_CORE=$(mpstat -P ALL 1 1 | awk '/Average/ && $2 ~ /[0-9]/ {usage=100-$12; printf "{\"core\":\"%s\",\"usage\":%.1f},", $2, usage}' | sed 's/,$//')
 cpu_data=$(echo "[$CPU_USAGE_PER_CORE]")
 
-# 🌡️ Température CPU
-TEMP=$(sensors 2>/dev/null | grep -m1 -Eo '[+-][0-9]+\.[0-9]°C' || echo "N/A")
+# 🌡️ Température CPU par cœur
+# Certaines implémentations de `sensors` préfixent les lignes par des espaces.
+# On autorise donc les espaces initiaux et on supprime les symboles avant de
+# construire le JSON. Si aucun cœur n'est détecté, on retourne un tableau vide.
+TEMP_CORES=$(sensors 2>/dev/null \
+  | grep -E '^[[:space:]]*Core [0-9]+' \
+  | sed 's/^\s*//; s/+//g; s/°C//g' \
+  | awk '{core=$2; temp=$3; gsub(":","",core); printf "{\"core\":%s,\"temp\":%s}\\n",core,temp}' \
+  | jq -s '.')
+[ -z "$TEMP_CORES" ] && TEMP_CORES="[]"
 
 # 🎯 Couleur charge CPU
 cpu_total_usage=$(echo "$cpu_data" | jq '[.[] | .usage | tonumber] | add / length')
@@ -71,7 +79,7 @@ jq -n \
   --arg hostname "$HOSTNAME" \
   --arg ip_local "$IP_LOCAL" \
   --arg ip_pub "$IP_PUBLIQUE" \
-  --arg temp_cpu "$TEMP" \
+  --argjson temp_cores "$TEMP_CORES" \
   --argjson memory "$MEMORY" \
   --argjson swap "$SWAP" \
   --argjson disk_root "$DISK_ROOT" \
@@ -92,7 +100,6 @@ jq -n \
     ip_pub: $ip_pub,
     uptime: $uptime,
     load_average: $load_avg,
-    temperature: $temp_cpu,
     memory: {
       ram: $memory,
       swap: $swap
@@ -101,7 +108,8 @@ jq -n \
     cpu: {
       model: $cpu_model,
       cores: $cpu_cores,
-      usage: $cpu_usage
+      usage: $cpu_usage,
+      temperatures: $temp_cores
     },
     cpu_load_color: $cpu_color,
     services: $services,


### PR DESCRIPTION
## Summary
- capture per-core CPU temperatures in audit script and embed in JSON
- render per-core temperature bars in viewer with fallback for invalid values
- update audit page to show multiple CPU temperature bars

## Testing
- `bash generate-audit-json.sh` *(fails: mpstat: command not found; bc: command not found; ss: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc9d2c00832d9591b50f9849492d