### PR TITLE
feat: adjust temperature bar colors

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -125,9 +125,14 @@ function renderText(json) {
       if (!isNaN(value)) {
         const percentage = Math.min(100, Math.max(0, value));
         fill.style.width = percentage + "%";
-        if (value < 50) fill.classList.add("green");
-        else if (value < 70) fill.classList.add("orange");
-        else fill.classList.add("red");
+        // Color zones: 0-80°C green, 80-95°C orange, 95°C+ red
+        if (value < 80) {
+          fill.classList.add("green");
+        } else if (value < 95) {
+          fill.classList.add("orange");
+        } else {
+          fill.classList.add("red");
+        }
       }
       bar.appendChild(fill);
       wrapper.appendChild(bar);


### PR DESCRIPTION
## Summary
- tune temperature bar colors to use 0-80°C green, 80-95°C orange, and 95°C+ red

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d2e595f4832d8fb606345a925a89