### PR TITLE
feat: add audit search filter

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -361,6 +361,7 @@
 
   <label for="auditSelector">Sélectionner un rapport :</label>
   <select id="auditSelector"></select>
+  <input type="text" id="auditSearch">
 
   <h2>Date de génération</h2>
   <p id="generated">--</p>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -218,9 +218,18 @@ function renderText(json) {
   document.getElementById('dockerText').textContent = docker;
 }
 
+function filterAudits(query) {
+  const selector = document.getElementById('auditSelector');
+  const q = query.toLowerCase();
+  Array.from(selector.options).forEach(opt => {
+    opt.style.display = opt.textContent.toLowerCase().includes(q) ? '' : 'none';
+  });
+}
+
 async function init() {
   const list = await fetchIndex();
   const selector = document.getElementById('auditSelector');
+  const search = document.getElementById('auditSearch');
 
   list.forEach(file => {
     const option = document.createElement('option');
@@ -228,6 +237,8 @@ async function init() {
     option.textContent = decodeURIComponent(file.replace('audit_', '').replace('.json', '').replace('_', ' à '));
     selector.appendChild(option);
   });
+
+  search.addEventListener('input', e => filterAudits(e.target.value));
 
   selector.addEventListener('change', async (e) => {
     const json = await loadAudit(e.target.value);


### PR DESCRIPTION
## Summary
- add text input for audit search
- implement filterAudits to hide non-matching options
- bind input listener to filter audits in selector

## Testing
- `node --check audits/scripts/viewer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa4387e8832db8571c395f098cab