### PR TITLE
Affiche l'uptime et la charge moyenne

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -366,6 +366,11 @@
   <h2>Date de génération</h2>
   <p id="generated">--</p>
 
+  <h2>Temps de fonctionnement</h2>
+  <p id="uptime">--</p>
+  <h2>Charge moyenne</h2>
+  <p id="loadAvg">--</p>
+
   <h2>Adressage réseau</h2>
   <div id="ipInfo" class="ip-container">
     <div><span class="ip-icon">📡</span> IP Locale : <span id="ipLocal">--</span></div>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -46,6 +46,8 @@ function renderText(json) {
   document.getElementById('generated').textContent = json.generated;
   document.getElementById('hostname').textContent = json.hostname;
   document.getElementById('ipInfo').textContent = `${json.ip_local || 'N/A'} / ${json.ip_pub || 'N/A'}`;
+  document.getElementById('uptime').textContent = json.uptime || '--';
+  document.getElementById('loadAvg').textContent = json.load_average || '--';
 
   const mem = json.memory?.ram;
   if (mem) {


### PR DESCRIPTION
## Summary
- Add uptime and load average sections to the audit report page
- Populate uptime and load average from audit JSON in viewer script

## Testing
- `bash generate-audit-json.sh`

------
https://chatgpt.com/codex/tasks/task_e_6899fb707e98832dbf68f8b033368a14