### PR TITLE
Fix search input initialization in audit viewer

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -240,7 +240,10 @@ async function init() {
     selector.appendChild(option);
   });
 
-  search.addEventListener('input', e => filterAudits(e.target.value));
+  // Attach search filtering if the search input exists
+  if (search) {
+    search.addEventListener('input', e => filterAudits(e.target.value));
+  }
 
   selector.addEventListener('change', async (e) => {
     const json = await loadAudit(e.target.value);
@@ -271,7 +274,9 @@ async function refreshAudits() {
   });
 
   // Reapply current search filter if any
-  filterAudits(search.value);
+  if (search) {
+    filterAudits(search.value);
+  }
 
   if (list.length > 0) {
     const latest = list[list.length - 1];
@@ -284,6 +289,9 @@ async function refreshAudits() {
   }
 }
 
-init().then(() => {
-  setInterval(refreshAudits, 60000);
+// Ensure initialization runs after the DOM is fully loaded
+document.addEventListener('DOMContentLoaded', () => {
+  init().then(() => {
+    setInterval(refreshAudits, 60000);
+  });
 });


### PR DESCRIPTION
## Summary
- avoid null access when audit search input is missing
- initialize viewer only after DOM has loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a01e4750c832daac7b716ad04f610