### PR TITLE
Simplify audit report selector

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -381,17 +381,8 @@
   <h1>🧠 Audit Serveur DW</h1>
   <p class="subtitle">Machine : <strong id="hostname">-</strong></p>
 
-  <div id="selectorContainer">
-    <div>
-      <label for="auditDate">Choisir une date :</label>
-      <input type="date" id="auditDate" list="auditDates">
-      <datalist id="auditDates"></datalist>
-    </div>
-    <div>
-      <label for="auditSelector">Rapports disponibles :</label>
-      <select id="auditSelector"></select>
-    </div>
-  </div>
+  <label for="auditSelector">Rapports disponibles :</label>
+  <select id="auditSelector"></select>
 
   <h2><i class="fa-solid fa-calendar-day heading-icon"></i>Date de génération</h2>
   <p id="generated">--</p>


### PR DESCRIPTION
## Summary
- replace date and list inputs with single report selector
- generate optgroup/options in viewer
- load latest report by default and refresh accordingly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ad7b06788832d84fd44e05e924dc8