### PR TITLE
Simplify reports card and improve timeline

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -100,18 +100,7 @@
       position: relative;
     }
 
-    .report-card.compact .time-chip { padding: 0.2rem 0.5rem; }
-    .report-card.compact .time-list-item { padding: 0.1rem 0; }
-
-    .priority-bar {
-      display: flex;
-      gap: 1rem;
-      align-items: stretch;
-      flex-wrap: wrap;
-    }
-
-    .priority-bar .btn.primary {
-      flex: 1;
+    #btnLatest {
       display: flex;
       align-items: flex-start;
       justify-content: center;
@@ -119,11 +108,33 @@
       font-size: 1rem;
     }
 
-    .priority-bar .btn.primary i { margin-right: 0.5rem; }
-    .priority-bar .btn.primary .label { font-weight: bold; }
-    .priority-bar .btn.primary .subinfo {
+    #btnLatest i { margin-right: 0.5rem; }
+    #btnLatest .label { font-weight: bold; }
+    #btnLatest .subinfo {
       font-size: 0.8rem;
       opacity: 0.8;
+    }
+
+    .report-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    @media (min-width: 601px) {
+      .report-grid {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-areas:
+          "btn day"
+          "timeline timeline"
+          "status status";
+        gap: 0.5rem;
+      }
+      #btnLatest { grid-area: btn; }
+      .timeline-wrapper { grid-area: timeline; }
+      #selectorStatus { grid-area: status; }
+      .day-control { grid-area: day; justify-self: end; }
     }
 
     .day-control {
@@ -140,61 +151,52 @@
       border: none;
       cursor: pointer;
       flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
+    .day-control .seg:hover { background: #333; }
+    .day-control .seg:active { background: #444; }
     .day-control .seg.active {
       background: var(--heading);
       color: var(--bg);
     }
 
-    .timeline-tools { margin-top: 1rem; display: flex; flex-direction: column; gap: 0.5rem; }
-    .timeline-wrapper { overflow-x: auto; padding-bottom: 0.5rem; }
+    .day-control .seg:focus-visible {
+      outline: 2px solid var(--heading);
+      outline-offset: -2px;
+    }
+
+    .timeline-wrapper {
+      overflow-x: auto;
+      padding: 0.5rem;
+    }
+
     .timeline { display: flex; gap: 0.5rem; }
 
     .time-chip {
       background: #444;
-      border-radius: 20px;
+      color: var(--text);
+      border: none;
+      border-radius: 9999px;
       padding: 0.4rem 0.8rem;
-      border: 2px solid transparent;
       cursor: pointer;
       white-space: nowrap;
     }
 
+    .time-chip:hover { background: #555; }
+    .time-chip:active { background: #666; }
+
     .time-chip.active {
       background: var(--heading);
       color: var(--bg);
-      border-color: var(--heading);
     }
 
-    .time-chip .badge {
-      margin-left: 0.3rem;
-      font-size: 0.7rem;
-      background: var(--subheading);
-      color: var(--bg);
-      padding: 0 0.3rem;
-      border-radius: 4px;
+    .time-chip:focus-visible {
+      outline: 2px solid var(--heading);
+      outline-offset: 4px;
     }
-
-    .tools { display: flex; gap: 0.5rem; justify-content: flex-end; align-items: center; }
-    .tools input { flex: 1; }
-
-    .accordion { margin-top: 1rem; }
-    .accordion-header {
-      width: 100%;
-      text-align: left;
-      background: transparent;
-      border: none;
-      padding: 0.5rem 0;
-      font-weight: bold;
-      cursor: pointer;
-    }
-
-    .accordion-content { display: none; max-height: 200px; overflow-y: auto; }
-    .accordion.open .accordion-content { display: block; }
-
-    .time-list-item { display: flex; justify-content: space-between; align-items: center; padding: 0.3rem 0; }
-    .time-list-item .info { display: flex; flex-direction: column; }
-    .time-list-item .info small { opacity: 0.7; }
 
     .refresh-dot {
       width: 12px;
@@ -253,7 +255,7 @@
     }
 
     #selectorStatus {
-      margin-bottom: 1rem;
+      margin: 0;
     }
 
     #selectorStatus.error { color: #ff5555; }
@@ -385,8 +387,7 @@
       .switch input:checked + .slider:before {
         transform: translateX(20px);
       }
-      .priority-bar { flex-direction: column; }
-      .tools { flex-direction: column; align-items: stretch; }
+      .report-grid { display: flex; }
     }
 
     .temp-wrapper {
@@ -578,38 +579,29 @@
       <p class="subtitle">Choisissez un moment</p>
     </div>
 
-    <div class="priority-bar">
+    <div class="report-grid">
       <button id="btnLatest" class="btn primary">
         <span><i class="fa-solid fa-bolt"></i></span>
         <span class="label">Voir le dernier rapport</span>
         <small id="latestInfo" class="subinfo"></small>
       </button>
+
+      <div class="timeline-wrapper">
+        <div id="timeTimeline" class="timeline" aria-live="polite"></div>
+      </div>
+
+      <div id="selectorStatus" aria-live="polite"></div>
+
       <div class="day-control" role="group" aria-label="Choisir un jour">
         <button id="dayToday" class="seg">Aujourd'hui</button>
         <button id="dayYesterday" class="seg">Hier</button>
-        <button id="dayCalendar" class="seg">Calendrier…</button>
+        <button id="dayCalendar" class="seg" aria-label="Choisir une date" title="Choisir une date"><i class="fa-solid fa-calendar"></i></button>
         <input type="date" id="datePicker" class="sr-only" />
       </div>
     </div>
 
-    <div class="timeline-tools">
-      <div class="timeline-wrapper">
-        <div id="timeTimeline" class="timeline" aria-live="polite"></div>
-      </div>
-      <div class="tools">
-        <input id="timeFilter" type="text" placeholder="Filtrer une heure… Ex. 06 ou 06:30">
-        <button id="densityToggle" class="btn density" title="Changer la densité"><i class="fa-solid fa-bars"></i></button>
-      </div>
-    </div>
-
-    <div id="listAccordion" class="accordion">
-      <button id="listToggle" class="accordion-header">Liste des heures</button>
-      <div id="timeList" class="accordion-content"></div>
-    </div>
-
     <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>
     <span id="updateBadge" class="update-badge">Mis à jour</span>
-    <div id="selectorStatus" aria-live="polite"></div>
   </div>
 
   <h2><i class="fa-solid fa-calendar-day heading-icon"></i>Date de génération</h2>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -59,8 +59,7 @@ function showStatus(message, type) {
     div.innerHTML = `${message} <button id="retryBtn" class="btn">Réessayer</button>`;
     document.getElementById('retryBtn').addEventListener('click', init);
   } else if (type === 'empty') {
-    div.innerHTML = `${message} <button id="changeDayBtn" class="btn">Changer de jour</button>`;
-    document.getElementById('changeDayBtn').addEventListener('click', () => document.getElementById('dayCalendar').click());
+    div.textContent = message;
   } else {
     div.textContent = message || '';
   }
@@ -81,30 +80,15 @@ function renderTimeline(list) {
   });
 }
 
-function renderList(list) {
-  const container = document.getElementById('timeList');
-  container.innerHTML = '';
-  list.forEach(item => {
-    const row = document.createElement('div');
-    row.className = 'time-list-item';
-    row.dataset.file = item.file;
-    row.innerHTML = `<div class="info"><span>${item.time}</span><small>${formatRelative(item.iso)}</small></div><button class="btn open">Ouvrir</button>`;
-    row.querySelector('button').addEventListener('click', () => selectTime(item.file));
-    container.appendChild(row);
-  });
-}
-
 function populateDay(day) {
   const list = auditsMap[day] || [];
   if (list.length === 0) {
-    showStatus('Aucun rapport ce jour', 'empty');
     renderTimeline([]);
-    renderList([]);
+    showStatus('Aucune heure disponible', 'empty');
     return null;
   }
   showStatus('');
   renderTimeline(list);
-  renderList(list);
   const last = list[list.length - 1];
   setActiveTime(last.file);
   return last.file;
@@ -112,7 +96,6 @@ function populateDay(day) {
 
 function setActiveTime(file) {
   document.querySelectorAll('.time-chip').forEach(b => b.classList.toggle('active', b.dataset.file === file));
-  document.querySelectorAll('.time-list-item').forEach(li => li.classList.toggle('active', li.dataset.file === file));
 }
 
 async function selectTime(file) {
@@ -123,17 +106,6 @@ async function selectTime(file) {
     renderText(json);
     setActiveTime(file);
   }
-}
-
-function applyTimeFilter(q) {
-  const query = q.toLowerCase();
-  document.querySelectorAll('.time-chip').forEach(btn => {
-    btn.hidden = !btn.textContent.toLowerCase().includes(query);
-  });
-  document.querySelectorAll('.time-list-item').forEach(item => {
-    const timeText = item.querySelector('.info span').textContent.toLowerCase();
-    item.hidden = !timeText.includes(query);
-  });
 }
 
 function updateDayButtons() {
@@ -388,8 +360,6 @@ async function init() {
     return;
   }
 
-  const timeFilter = document.getElementById('timeFilter');
-  timeFilter.addEventListener('input', e => applyTimeFilter(e.target.value));
 
   document.getElementById('btnLatest').addEventListener('click', async () => {
     if (!latestEntry) return;
@@ -431,13 +401,6 @@ async function init() {
     if (file) selectTime(file);
   });
 
-  document.getElementById('densityToggle').addEventListener('click', () => {
-    document.getElementById('reportCard').classList.toggle('compact');
-  });
-
-  const listAccordion = document.getElementById('listAccordion');
-  document.getElementById('listToggle').addEventListener('click', () => listAccordion.classList.toggle('open'));
-  if (window.matchMedia('(min-width:768px)').matches) listAccordion.classList.add('open');
 
   setInterval(refreshAudits, 60000);
 }


### PR DESCRIPTION
## Summary
- streamline the Rapports card to focus on latest report, hourly timeline, and day selector
- replace calendar text with accessible icon button and show "Aucune heure disponible" when empty
- polish timeline chip styles to preserve focus halos and add responsive layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae4766868832daf8503d9e0724a50