### PR TITLE
fix: improve load legend spacing

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -572,7 +572,13 @@
     .gauge .bg { fill: none; stroke: #444; stroke-width: 4; }
     .gauge .progress { fill: none; stroke: var(--load-color, #4caf50); stroke-width: 4; stroke-linecap: round; transition: stroke 0.3s; }
     .gauge-value { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 2rem; font-weight: bold; display: flex; align-items: baseline; }
-    .gauge-label { text-align: center; margin-top: 0.25rem; font-size: 0.8rem; opacity: 0.8; }
+    .gauge-label {
+      text-align: center;
+      margin-top: 0.5rem;
+      font-size: 1rem;
+      line-height: 1.3;
+      opacity: 0.8;
+    }
     .trend { font-size: 1rem; margin-left: 0.25rem; }
 
     .load-cards {
@@ -597,7 +603,16 @@
     .mini-trend { font-size: 0.8rem; opacity: 0.8; margin-top: 0.25rem; }
     .mini-card.na { opacity: 0.5; }
 
-    .load-legend { margin-top: 0.5rem; display: flex; gap: 1rem; font-size: 0.8rem; justify-content: center; }
+    .load-legend {
+      margin-top: 0.75rem;
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+      font-size: 0.85rem;
+      line-height: 1.2;
+    }
     .legend-item { display: flex; align-items: center; gap: 0.25rem; }
     .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
     .dot.green { background: #4caf50; }
@@ -698,8 +713,8 @@
           <path id="loadGaugePath" class="progress" d="M18 2a16 16 0 1 1 0 32 16 16 0 1 1 0-32" stroke-dasharray="0 100"/>
         </svg>
         <div class="gauge-value"><span id="load1Val">--</span><span id="loadTrend" class="trend">→</span></div>
-        <div class="gauge-label">charge sur 1 min</div>
       </div>
+      <div class="gauge-label">charge sur 1 min</div>
       <div class="load-legend">
         <span class="legend-item"><span class="dot green"></span> Faible</span>
         <span class="legend-item"><span class="dot orange"></span> Élevée</span>


### PR DESCRIPTION
## Summary
- avoid legend overlap by stacking it beneath donut title
- use flex layout with consistent gaps and wrap for legend

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aeb8d70e8832d8955df9bd95f6a6d