### PR TITLE
Refactor active services block with searchable cards

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -619,6 +619,123 @@
     .dot.orange { background: #ff9800; }
     .dot.red { background: #f44336; }
 
+    .services-title-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .services-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .services-help {
+      font-size: 0.9rem;
+      color: #bbb;
+      margin-top: -0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    #serviceSearch {
+      width: 100%;
+      margin-bottom: 0.5rem;
+    }
+    .filter-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .filter-chip {
+      background: #444;
+      color: var(--text);
+      border: none;
+      border-radius: 9999px;
+      padding: 0.25rem 0.6rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .filter-chip.active {
+      background: var(--heading);
+      color: var(--bg);
+    }
+    .services-toolbar {
+      display: flex;
+      justify-content: flex-end;
+      margin-bottom: 0.5rem;
+    }
+    .services-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+      gap: 0.5rem;
+    }
+    .service-item {
+      background: var(--block-bg);
+      padding: 0.5rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .service-item:focus-visible {
+      outline: 2px solid var(--heading);
+      outline-offset: 2px;
+    }
+    .service-main {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .service-icon {
+      width: 1.5rem;
+      text-align: center;
+    }
+    .service-name {
+      font-weight: bold;
+    }
+    .service-badge {
+      margin-left: auto;
+      padding: 0.1rem 0.4rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      background: #555;
+    }
+    .service-details {
+      display: none;
+      margin-top: 0.5rem;
+      font-size: 0.85rem;
+    }
+    .service-item.expanded .service-details {
+      display: block;
+    }
+    .copy-btn.small {
+      font-size: 0.8rem;
+      padding: 0.2rem;
+      margin-left: 0.3rem;
+    }
+    .service-skeleton {
+      height: 2rem;
+      border-radius: 6px;
+    }
+    .empty {
+      text-align: center;
+      padding: 1rem 0;
+      color: #bbb;
+    }
+    .empty.hidden { display: none; }
+    .service-badge.cat-systeme { background: #6c757d; }
+    .service-badge.cat-reseau { background: #0d6efd; }
+    .service-badge.cat-stockage-partages { background: #6f42c1; }
+    .service-badge.cat-conteneurs { background: #198754; }
+    .service-badge.cat-securite { background: #d63384; }
+    .service-badge.cat-journalisation { background: #fd7e14; }
+    .service-badge.cat-mises-a-jour { background: #20c997; }
+    .service-badge.cat-autre { background: #adb5bd; }
+
+    @media (max-width: 600px) {
+      .services-grid { grid-template-columns: 1fr; }
+      .services-toolbar { justify-content: flex-start; }
+      .filter-chips { position: sticky; top: 0; background: var(--bg); padding-top: 0.5rem; }
+    }
+
     .gauge:focus-visible,
     .mini-card:focus-visible { outline: 2px solid var(--heading); outline-offset: 4px; }
 
@@ -757,10 +874,33 @@
   <h2><i class="fa-solid fa-hard-drive heading-icon"></i>Disques</h2>
   <div id="disksContainer" class="disk-bar-container"></div>
 
-  <h2><i class="fa-solid fa-list-check heading-icon"></i>Services actifs</h2>
+  <div class="services-title-row">
+    <h2><i class="fa-solid fa-list-check heading-icon"></i>Services actifs</h2>
+    <div class="services-actions">
+      <span id="servicesCount">0 service</span>
+      <button id="copyServicesBtn" class="copy-btn" title="Copier tous les noms">📋</button>
+    </div>
+  </div>
+  <p class="services-help">Survolez un service pour voir sa description.</p>
   <div class="block-wrapper">
-    <button class="copy-btn" onclick="copyToClipboard('servicesText')">📋</button>
-    <pre id="servicesText" class="code-block"></pre>
+    <input type="text" id="serviceSearch" placeholder="Filtrer un service… ex. ssh" />
+    <div id="categoryFilters" class="filter-chips"></div>
+    <div class="services-toolbar">
+      <select id="serviceSort">
+        <option value="az">A→Z</option>
+        <option value="za">Z→A</option>
+        <option value="cat">Par catégorie</option>
+      </select>
+    </div>
+    <div id="servicesList" class="services-grid">
+      <div class="service-skeleton skeleton"></div>
+      <div class="service-skeleton skeleton"></div>
+      <div class="service-skeleton skeleton"></div>
+    </div>
+    <div id="servicesEmpty" class="empty hidden">
+      Aucun service ne correspond au filtre.
+      <button id="resetFilters" class="btn">Réinitialiser les filtres</button>
+    </div>
   </div>
 
   <h2><i class="fa-solid fa-plug heading-icon"></i>Ports ouverts</h2>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -7,6 +7,115 @@ let latestEntry = null;
 let currentFile = null;
 let selectedDate = null;
 
+const SERVICE_CATEGORIES = ['Système', 'Réseau', 'Stockage/Partages', 'Conteneurs', 'Sécurité', 'Journalisation', 'Mises à jour', 'Autre'];
+const SERVICE_PATTERNS = [
+  {regex:/docker|containerd/i, icon:'🐳', category:'Conteneurs'},
+  {regex:/ssh/i, icon:'🔐', category:'Sécurité'},
+  {regex:/cron/i, icon:'⏱️', category:'Système'},
+  {regex:/dbus/i, icon:'🔌', category:'Système'},
+  {regex:/ntp|ntpsec|timesync/i, icon:'🕒', category:'Réseau'},
+  {regex:/rpcbind/i, icon:'🧭', category:'Réseau'},
+  {regex:/rpc|nfs/i, icon:'📡', category:'Réseau'},
+  {regex:/smb|smbd|nmbd|cifs/i, icon:'🗂️', category:'Stockage/Partages'},
+  {regex:/systemd-(journald|logind|networkd|resolved|udevd)/i, icon:'⚙️', category:'Système'},
+  {regex:/rsyslog/i, icon:'📝', category:'Journalisation'},
+  {regex:/bluetooth/i, icon:'📶', category:'Réseau'},
+  {regex:/unattended-upgrades/i, icon:'🔄', category:'Mises à jour'},
+  {regex:/thermald/i, icon:'🌡️', category:'Système'},
+];
+
+let servicesData = [];
+let filteredServices = [];
+let activeServiceCats = new Set(SERVICE_CATEGORIES);
+let serviceSearch = '';
+let serviceSort = 'az';
+let servicesInit = false;
+
+function getServiceMeta(name){
+  for (const p of SERVICE_PATTERNS){
+    if (p.regex.test(name)) return p;
+  }
+  return {icon:'⬜', category:'Autre'};
+}
+
+function initServicesUI(){
+  if (servicesInit) return;
+  servicesInit = true;
+  const searchInput = document.getElementById('serviceSearch');
+  const sortSelect = document.getElementById('serviceSort');
+  const filtersDiv = document.getElementById('categoryFilters');
+  SERVICE_CATEGORIES.forEach(cat => {
+    const chip = document.createElement('button');
+    chip.className = 'filter-chip active';
+    chip.textContent = cat;
+    chip.dataset.cat = cat;
+    chip.addEventListener('click', () => {
+      if (activeServiceCats.has(cat)) activeServiceCats.delete(cat); else activeServiceCats.add(cat);
+      chip.classList.toggle('active');
+      applyServiceFilters();
+    });
+    filtersDiv.appendChild(chip);
+  });
+  searchInput.addEventListener('input', e => { serviceSearch = e.target.value.toLowerCase(); applyServiceFilters(); });
+  sortSelect.addEventListener('change', e => { serviceSort = e.target.value; applyServiceFilters(); });
+  document.getElementById('copyServicesBtn').addEventListener('click', () => {
+    navigator.clipboard.writeText(filteredServices.map(s=>s.name).join('\n')).then(()=>alert('Copié dans le presse-papiers !'));
+  });
+  document.getElementById('resetFilters').addEventListener('click', () => {
+    serviceSearch = '';
+    serviceSort = 'az';
+    activeServiceCats = new Set(SERVICE_CATEGORIES);
+    searchInput.value = '';
+    sortSelect.value = 'az';
+    document.querySelectorAll('#categoryFilters .filter-chip').forEach(c => c.classList.add('active'));
+    applyServiceFilters();
+  });
+}
+
+function applyServiceFilters(){
+  filteredServices = servicesData.filter(s => activeServiceCats.has(s.category) && s.name.toLowerCase().includes(serviceSearch));
+  if (serviceSort === 'az') filteredServices.sort((a,b)=>a.name.localeCompare(b.name));
+  else if (serviceSort === 'za') filteredServices.sort((a,b)=>b.name.localeCompare(a.name));
+  else if (serviceSort === 'cat') filteredServices.sort((a,b)=>a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
+  renderServicesList();
+}
+
+function renderServicesList(){
+  const list = document.getElementById('servicesList');
+  list.innerHTML = '';
+  const countSpan = document.getElementById('servicesCount');
+  if (filteredServices.length === 0){
+    countSpan.textContent = '0 service';
+    document.getElementById('servicesEmpty').classList.remove('hidden');
+    return;
+  }
+  document.getElementById('servicesEmpty').classList.add('hidden');
+  filteredServices.forEach(s => {
+    const item = document.createElement('div');
+    item.className = 'service-item';
+    item.tabIndex = 0;
+    item.title = s.desc;
+    item.setAttribute('aria-expanded', 'false');
+    item.innerHTML = `<div class="service-main"><span class="service-icon">${s.icon}</span><span class="service-name">${s.name}</span><span class="service-badge cat-${s.category.toLowerCase().replace(/[\s/]+/g,'-')}">${s.category}</span></div><div class="service-details"><div><strong>Nom de l’unité :</strong> <code>${s.name}</code> <button class="copy-btn small" title="Copier le nom">📋</button></div><div><strong>Type :</strong> service</div><div><strong>Description :</strong> ${s.desc}</div></div>`;
+    const copyBtn = item.querySelector('.copy-btn');
+    copyBtn.addEventListener('click', e => { e.stopPropagation(); navigator.clipboard.writeText(s.name).then(()=>alert('Copié dans le presse-papiers !')); });
+    const toggle = () => {
+      const expanded = item.classList.toggle('expanded');
+      item.setAttribute('aria-expanded', expanded);
+    };
+    item.addEventListener('click', toggle);
+    item.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } });
+    list.appendChild(item);
+  });
+  countSpan.textContent = `${filteredServices.length} service${filteredServices.length>1?'s':''}`;
+}
+
+function renderServices(names){
+  initServicesUI();
+  servicesData = (names || []).map(n => { const meta = getServiceMeta(n); return {name:n, icon:meta.icon, category:meta.category, desc:'Service systemd'}; });
+  applyServiceFilters();
+}
+
 async function fetchIndex() {
   const res = await fetch('/archives/index.json');
   return await res.json();
@@ -341,7 +450,7 @@ function renderText(json) {
   badge.textContent = json.cpu_load_color?.toUpperCase() || "N/A";
   badge.className = "badge " + color;
 
-  document.getElementById('servicesText').textContent = json.services?.join('\n') || 'Aucun service';
+  renderServices(json.services);
 
   // 🧠 Ajout d’une fonction robuste pour extraire les IP
   function extractIp(portStr) {


### PR DESCRIPTION
## Summary
- redesign services section into filterable cards with category badges and copy list support
- add icon and category mapping with search, filters, sorting and detail accordion

## Testing
- `npm test` *(fails: enoent Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aed164574832db087835bdd7bfabd