### PR TITLE
Fix duplicate legend in ports section

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -470,7 +470,7 @@
     }
     .ports-legend {
       font-size: 0.9rem;
-      margin-bottom: 0.5rem;
+      margin: 0.5rem 0;
       display: flex;
       flex-wrap: wrap;
       gap: 0.5rem;
@@ -870,11 +870,7 @@
 
   <h2><i class="fa-solid fa-plug heading-icon"></i>Ports ouverts <span id="portsTotal" class="badge">0</span></h2>
   <p class="subtitle">Interfaces et services détectés</p>
-  <div class="ports-legend">
-    <span><span class="risk-dot low"></span>🟢 faible risque</span>
-    <span><span class="risk-dot medium"></span>🟠 exposé localement</span>
-    <span><span class="risk-dot high"></span>🔴 potentiellement exposé / critique</span>
-  </div>
+  <div id="portsLegend" class="ports-legend"></div>
   <div class="ports-toolbar">
     <input type="text" id="portSearch" placeholder="Filtrer… ex. 22, ssh, 0.0.0.0" />
     <div id="portFilters" class="filter-chips"></div>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -197,6 +197,19 @@ function initPortsUI(){
   const searchInput = document.getElementById('portSearch');
   const filtersDiv = document.getElementById('portFilters');
   const sortSelect = document.getElementById('portSort');
+  const legendDiv = document.getElementById('portsLegend');
+  if (legendDiv){
+    legendDiv.innerHTML='';
+    [
+      {cls:'low', label:'faible risque'},
+      {cls:'medium', label:'exposé localement'},
+      {cls:'high', label:'potentiellement exposé / critique'}
+    ].forEach(item=>{
+      const span=document.createElement('span');
+      span.innerHTML=`<span class="risk-dot ${item.cls}"></span>${item.label}`;
+      legendDiv.appendChild(span);
+    });
+  }
   PORT_FILTERS.forEach(f => {
     const chip = document.createElement('button');
     chip.className='filter-chip active';


### PR DESCRIPTION
## Summary
- Dynamically build the ports risk legend to avoid duplicate bullets
- Trim HTML to a single legend container and adjust styling margins

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af4c05948832d95912d85ea235594