### PR TITLE
Fix jq conditional for Docker health in audit script

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -106,9 +106,9 @@ if command -v docker >/dev/null 2>&1; then
       health=$(echo "$status" | sed -n 's/.*(\([^)]*\)).*/\1/p')
 
       if [[ -n "${CPU[$name]+x}" ]]; then
-        DOCKER_CONTAINERS=$(echo "$DOCKER_CONTAINERS" | jq --arg name "$name" --arg state "$state" --arg uptime "$running_for" --arg health "$health" --arg cpu "${CPU[$name]}" --arg mempct "${MEM_PCT[$name]}" --arg memused "${MEM_USED[$name]}" --arg memlimit "${MEM_LIMIT[$name]}" '. + [{name:$name,state:$state,health:($health==""?null:$health),uptime:$uptime,has_stats:true,cpu_pct:($cpu|tonumber),mem_pct:($mempct|tonumber),mem_used_bytes:($memused|tonumber),mem_limit_bytes:($memlimit|tonumber)}]')
+        DOCKER_CONTAINERS=$(echo "$DOCKER_CONTAINERS" | jq --arg name "$name" --arg state "$state" --arg uptime "$running_for" --arg health "$health" --arg cpu "${CPU[$name]}" --arg mempct "${MEM_PCT[$name]}" --arg memused "${MEM_USED[$name]}" --arg memlimit "${MEM_LIMIT[$name]}" '. + [{name:$name,state:$state,health:(if $health=="" then null else $health end),uptime:$uptime,has_stats:true,cpu_pct:($cpu|tonumber),mem_pct:($mempct|tonumber),mem_used_bytes:($memused|tonumber),mem_limit_bytes:($memlimit|tonumber)}]')
       else
-        DOCKER_CONTAINERS=$(echo "$DOCKER_CONTAINERS" | jq --arg name "$name" --arg state "$state" --arg uptime "$running_for" --arg health "$health" '. + [{name:$name,state:$state,health:($health==""?null:$health),uptime:$uptime,has_stats:false,cpu_pct:null,mem_pct:null,mem_used_bytes:null,mem_limit_bytes:null}]')
+        DOCKER_CONTAINERS=$(echo "$DOCKER_CONTAINERS" | jq --arg name "$name" --arg state "$state" --arg uptime "$running_for" --arg health "$health" '. + [{name:$name,state:$state,health:(if $health=="" then null else $health end),uptime:$uptime,has_stats:false,cpu_pct:null,mem_pct:null,mem_used_bytes:null,mem_limit_bytes:null}]')
       fi
     done <<< "$DOCKER_PS_OUTPUT"
   fi


### PR DESCRIPTION
## Summary
- correct jq conditional syntax when adding Docker container info
- make generate-audit-json.sh executable

## Testing
- `bash generate-audit-json.sh`

------
https://chatgpt.com/codex/tasks/task_e_689afc3a0cfc832da6124658fb4fe0a2