### PR TITLE
Align Top Process CPU/RAM bars

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -702,21 +702,29 @@
     }
     .proc-list { display: flex; flex-direction: column; gap: 0.5rem; }
     .proc-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem; border-radius: 6px; cursor: default; }
+    @media (max-width: 899px) { .proc-row { flex-wrap: wrap; } }
     .proc-row:hover { background: #333; }
     .proc-row:focus-visible { outline: 2px solid var(--heading); outline-offset: 2px; }
-    .proc-icon { width: 1.5rem; text-align: center; }
-    .proc-name { font-weight: bold; }
-    .proc-bars { flex: 1; display: flex; flex-direction: column; gap: 4px; margin: 0 0.5rem; }
-    .bar { position: relative; background: #444; border-radius: 4px; overflow: hidden; }
-    .bar.main { height: 8px; }
-    .bar.sub { height: 4px; }
-    .bar .fill { height: 100%; width: 0; transition: width 0.3s ease; }
-    .bar.sub .fill { background: #888; }
+    .proc-icon { width: 1.5rem; text-align: center; flex: 0 0 1.5rem; }
+    .proc-name { font-weight: bold; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    .proc-bars { display: flex; gap: 4px; flex: 1; height: 8px; }
+    .bar { flex: 1; position: relative; background: #444; border-radius: 4px; overflow: hidden; }
+    .bar .fill { display: block; height: 100%; width: 0; border-radius: 4px; transition: width 0.3s ease; }
     .fill.green { background: #4caf50; }
     .fill.orange { background: #ff9800; }
     .fill.red { background: #f44336; }
-    .proc-badges { font-size: 0.75rem; display: flex; gap: 0.25rem; }
-    .proc-badges .badge { background: #444; padding: 2px 4px; border-radius: 4px; }
+    .fill.blue { background: #2196f3; }
+    .fill.yellow { background: #ffeb3b; }
+    .proc-values { font-size: 0.75rem; display: flex; gap: 0.25rem; white-space: nowrap; }
+    .proc-values .badge { margin-left: 0; background: #444; padding: 2px 4px; border-radius: 4px; }
+    @media (min-width: 900px) {
+      .proc-name { flex: 0 0 12rem; }
+      .proc-values { flex: 0 0 6rem; justify-content: flex-end; }
+    }
+    @media (max-width: 899px) {
+      .proc-bars { flex: 1 0 100%; }
+      .proc-values { flex: 1 0 100%; justify-content: flex-end; }
+    }
     .proc-footer { margin-top: 0.25rem; font-size: 0.8rem; text-align: right; opacity: 0.8; }
 
     /* Docker */

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -58,10 +58,17 @@ function iconFor(name){
   return '⚙️';
 }
 
-function colorClass(v){
+function colorClassCpu(v){
   const val = Number(v);
   if (val < 40) return 'green';
   if (val < 70) return 'orange';
+  return 'red';
+}
+
+function colorClassRam(v){
+  const val = Number(v);
+  if (val < 40) return 'blue';
+  if (val < 70) return 'yellow';
   return 'red';
 }
 
@@ -383,15 +390,20 @@ function renderTopProcesses(data, containerId, main){
     row.className = 'proc-row';
     row.tabIndex = 0;
     row.title = `CPU ${cpu}% — RAM ${mem}%`;
-    const mainVal = main === 'cpu' ? cpu : mem;
-    const subVal = main === 'cpu' ? mem : cpu;
     const icon = iconFor(p.cmd);
-    row.innerHTML = `<span class="proc-icon">${icon}</span><span class="proc-name">${p.cmd}</span><div class="proc-bars"><div class="bar main"><div class="fill ${colorClass(mainVal)}"></div></div><div class="bar sub"><div class="fill"></div></div></div><div class="proc-badges"><span class="badge">CPU ${cpu}%</span><span class="badge">RAM ${mem}%</span></div>`;
+    row.innerHTML = `
+      <span class="proc-icon">${icon}</span>
+      <span class="proc-name">${p.cmd}</span>
+      <div class="proc-bars">
+        <div class="bar" role="progressbar" aria-label="Utilisation CPU" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${cpu}"><span class="fill ${colorClassCpu(cpu)}"></span></div>
+        <div class="bar" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${mem}"><span class="fill ${colorClassRam(mem)}"></span></div>
+      </div>
+      <div class="proc-values"><span class="badge">CPU ${cpu}%</span><span class="badge">RAM ${mem}%</span></div>`;
     container.appendChild(row);
-    const fills = row.querySelectorAll('.fill');
+    const fills = row.querySelectorAll('.bar .fill');
     requestAnimationFrame(() => {
-      fills[0].style.width = mainVal + '%';
-      fills[1].style.width = subVal + '%';
+      fills[0].style.width = cpu + '%';
+      fills[1].style.width = mem + '%';
     });
   });
   const footer = document.createElement('div');
@@ -488,8 +500,8 @@ function renderDockerList(){
     card.className = 'docker-card';
     card.tabIndex = 0;
     card.title = `CPU ${c.cpu}% — RAM ${c.mem}% — Status ${c.health}`;
-    const cpuColor = colorClass(c.cpu);
-    const ramColor = colorClass(c.mem);
+    const cpuColor = colorClassCpu(c.cpu);
+    const ramColor = colorClassRam(c.mem);
     const icon = iconFor(c.name);
     card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div><span class="status-badge status-${c.health}">${c.health}</span></div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div></div>${c.memText?`<div class="ram-text">${c.memText}</div>`:''}</div>`;
     grid.appendChild(card);


### PR DESCRIPTION
## Summary
- Align CPU and RAM progress bars with shared flex layout and responsive wrapping
- Differentiate CPU and RAM usage colors and add ARIA progressbar roles
- Standardize process badges and bar widths across Top CPU and Top RAM panels

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b0002948c832d934ac6ae011985ff