### PR TITLE
feat: improve process bar readability and totals

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -708,8 +708,34 @@
     .proc-icon { width: 1.5rem; text-align: center; flex: 0 0 1.5rem; }
     .proc-name { font-weight: bold; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
     .proc-bars { display: flex; gap: 8px; flex: 1; }
-    .bar { flex: 1; background: var(--bar-bg, #333); border-radius: 6px; overflow: hidden; height: 14px; position: relative; }
-    .bar .fill { display: flex; align-items: center; justify-content: center; height: 100%; width: 0; color: #fff; font-size: 0.75rem; font-weight: 600; white-space: nowrap; border-radius: 6px; transition: width 250ms ease; }
+    .bar {
+      flex: 1;
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 16px;
+      border-radius: 6px;
+      overflow: hidden;
+      background-color: var(--bar-bg, #333);
+    }
+    .bar .fill {
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 0;
+      border-radius: 6px;
+      transition: width 250ms ease;
+    }
+    .bar .value {
+      position: relative;
+      z-index: 1;
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 600;
+      white-space: nowrap;
+    }
     .fill.green { background: #4caf50; }
     .fill.orange { background: #ff9800; }
     .fill.red { background: #f44336; }
@@ -721,7 +747,35 @@
     @media (max-width: 899px) {
       .proc-bars { flex: 1 0 100%; }
     }
-    .proc-footer { margin-top: 0.25rem; font-size: 0.8rem; text-align: right; opacity: 0.8; }
+    .total-summary {
+      margin-top: 8px;
+      padding-top: 6px;
+      border-top: 1px solid rgba(255,255,255,0.1);
+      font-weight: 600;
+      font-size: 0.9rem;
+      text-align: right;
+      color: var(--accent-color, #4cafef);
+    }
+    .badge-total {
+      background-color: var(--accent-color, #4cafef);
+      color: #fff;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.85rem;
+    }
+    @media (max-width: 899px) {
+      .total-summary {
+        text-align: center;
+        max-width: 90%;
+        margin-left: auto;
+        margin-right: auto;
+      }
+    }
+    @media (min-width: 900px) {
+      .total-summary {
+        font-size: 1rem;
+      }
+    }
 
     /* Docker */
     .docker-toolbar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; align-items: center; }

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -395,20 +395,44 @@ function renderTopProcesses(data, containerId, main){
       <span class="proc-icon">${icon}</span>
       <span class="proc-name">${p.cmd}</span>
       <div class="proc-bars">
-        <div class="bar bar-cpu" role="progressbar" aria-label="Utilisation CPU" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${cpu}"><span class="fill ${colorClassCpu(cpu)}" style="width:0">${cpu}%</span></div>
-        <div class="bar bar-ram" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${mem}"><span class="fill ${colorClassRam(mem)}" style="width:0">${mem}%</span></div>
+        <div class="bar bar-cpu" role="progressbar" aria-label="Utilisation CPU" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${cpu}">
+          <span class="fill ${colorClassCpu(cpu)}" style="width:0"></span>
+          <span class="value">${cpu}%</span>
+        </div>
+        <div class="bar bar-ram" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${mem}">
+          <span class="fill ${colorClassRam(mem)}" style="width:0"></span>
+          <span class="value">${mem}%</span>
+        </div>
       </div>`;
     container.appendChild(row);
     const fills = row.querySelectorAll('.bar .fill');
+    const values = row.querySelectorAll('.bar .value');
     requestAnimationFrame(() => {
       fills[0].style.width = cpu + '%';
       fills[1].style.width = mem + '%';
+      adjustBarValue(values[0], fills[0], cpu);
+      adjustBarValue(values[1], fills[1], mem);
     });
   });
   const footer = document.createElement('div');
-  footer.className = 'proc-footer';
-  footer.textContent = `Total ${main === 'cpu' ? 'CPU' : 'RAM'} des 5 : ${total.toFixed(1)}%`;
+  footer.className = 'total-summary';
+  footer.innerHTML = `Total ${main === 'cpu' ? 'CPU' : 'RAM'} des 5 : <span class="badge-total">${total.toFixed(1)}%</span>`;
   container.appendChild(footer);
+}
+
+function contrastColor(bg){
+  const rgb = bg.match(/\d+/g).map(Number);
+  const luminance = 0.299*rgb[0] + 0.587*rgb[1] + 0.114*rgb[2];
+  return luminance > 140 ? '#000' : '#fff';
+}
+
+function adjustBarValue(valueEl, fillEl, val){
+  if (val >= 20){
+    const bg = getComputedStyle(fillEl).backgroundColor;
+    valueEl.style.color = contrastColor(bg);
+  } else {
+    valueEl.style.color = '#fff';
+  }
 }
 
 function parseDocker(item){


### PR DESCRIPTION
## Summary
- center CPU and RAM values within their bars and adjust text contrast on small fills
- highlight aggregated CPU and RAM usage with a badge-style total summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b041b68e8832da054f8ce93fc4118