### PR TITLE
Refactor memory and disk usage bars

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -463,8 +463,7 @@
     }
 
     .memory-container {
-      max-width: 400px;
-      margin: auto;
+      width: 100%;
       padding: 1rem 0;
     }
     .ports-legend {


### PR DESCRIPTION
## Summary
- add helpers to parse and format byte sizes
- revamp RAM usage display with a single accessible progress bar
- recompute disk usage from bytes with clean info line and fallback handling

## Testing
- `node --check audits/scripts/viewer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0c4f2700832db27972f660ffc9c1