### PR TITLE
feat: centralize color variables

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
   crossorigin="anonymous"
   referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="styles.css">
   <script src="/scripts/viewer.js?v=3"></script>
   <style>
     body.theme-dark {
@@ -433,7 +434,7 @@
     .temp-fill {
       height: 100%;
       width: 0%;
-      background-color: green;
+      background-color: var(--success);
       transition: width 0.5s ease, background-color 0.5s ease;
     }
     .badge {
@@ -451,9 +452,9 @@
       align-items: center;
       justify-content: space-between;
     }
-    .green  { background-color: #4caf50; color: white; }
-    .orange { background-color: #ff9800; color: black; }
-    .red    { background-color: #f44336; color: white; }
+    .color-success { background-color: var(--success); color: white; }
+    .color-warning { background-color: var(--warning); color: black; }
+    .color-danger  { background-color: var(--danger); color: white; }
 
     /* General info & network cards */
     .info-grid { display: flex; flex-direction: column; gap: 0.75rem; }
@@ -633,9 +634,9 @@
     }
     .legend-item { display: flex; align-items: center; gap: 0.25rem; }
     .dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
-    .dot.green { background: #4caf50; }
-    .dot.orange { background: #ff9800; }
-    .dot.red { background: #f44336; }
+    .dot.color-success { background: var(--success); }
+    .dot.color-warning { background: var(--warning); }
+    .dot.color-danger { background: var(--danger); }
 
     .services-title-row {
       display: flex;
@@ -789,11 +790,10 @@
       font-weight: 600;
       white-space: nowrap;
     }
-    .fill.green { background: #4caf50; }
-    .fill.orange { background: #ff9800; }
-    .fill.red { background: #f44336; }
-    .fill.blue { background: #2196f3; }
-    .fill.yellow { background: #ffeb3b; color: #000; }
+    .fill.color-success { background: var(--success); }
+    .fill.color-warning { background: var(--warning); color: #000; }
+    .fill.color-danger { background: var(--danger); }
+    .fill.color-info { background: var(--info); }
     @media (min-width: 900px) {
       .proc-name { flex: 0 0 12rem; }
     }
@@ -998,9 +998,9 @@
       </div>
       <div class="gauge-label">charge sur 1 min</div>
       <div class="load-legend">
-        <span class="legend-item"><span class="dot green"></span> Faible</span>
-        <span class="legend-item"><span class="dot orange"></span> Élevée</span>
-        <span class="legend-item"><span class="dot red"></span> Critique</span>
+        <span class="legend-item"><span class="dot color-success"></span> Faible</span>
+        <span class="legend-item"><span class="dot color-warning"></span> Élevée</span>
+        <span class="legend-item"><span class="dot color-danger"></span> Critique</span>
       </div>
     </div>
     <div class="load-cards">

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -59,30 +59,30 @@ function iconFor(name){
 
 function colorClassCpu(v){
   const val = Number(v);
-  if (val < 40) return 'green';
-  if (val < 70) return 'orange';
-  return 'red';
+  if (val < 40) return 'color-success';
+  if (val < 70) return 'color-warning';
+  return 'color-danger';
 }
 
 function colorClassRam(v){
   const val = Number(v);
-  if (val < 40) return 'blue';
-  if (val < 70) return 'yellow';
-  return 'red';
+  if (val < 40) return 'color-info';
+  if (val < 70) return 'color-warning';
+  return 'color-danger';
 }
 
 function colorClassTemp(v){
   const val = Number(v);
-  if (val < 60) return 'green';
-  if (val < 80) return 'orange';
-  return 'red';
+  if (val < 60) return 'color-success';
+  if (val < 80) return 'color-warning';
+  return 'color-danger';
 }
 
 function colorClassDisk(v){
   const val = Number(v);
-  if (val < 50) return 'green';
-  if (val < 80) return 'orange';
-  return 'red';
+  if (val < 50) return 'color-success';
+  if (val < 80) return 'color-warning';
+  return 'color-danger';
 }
 
 function parseSizeToBytes(val){
@@ -818,7 +818,7 @@ function renderMemory(mem){
   const freeStr = formatBytes(freeBytes);
   container.innerHTML = `
     <div id="memoryBar" class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${pctStr}">
-      <span class="fill green" style="width:0"></span>
+      <span class="fill color-info" style="width:0"></span>
       <span class="value">${pctStr}%</span>
     </div>
     <div class="ram-text">Utilisée : ${usedStr} / ${totalStr} • Libre : ${freeStr}</div>`;
@@ -905,9 +905,9 @@ function loadToPercent(load, cores) {
 
 function loadColor(v) {
   if (v == null) return '#666';
-  if (v < 70) return '#4caf50';
-  if (v < 100) return '#ff9800';
-  return '#f44336';
+  if (v < 70) return 'var(--success)';
+  if (v < 100) return 'var(--warning)';
+  return 'var(--danger)';
 }
 
 function arrowFromDiff(d) {
@@ -953,7 +953,7 @@ function renderLoadAverage(raw, cores) {
   const trendEl = document.getElementById('loadTrend');
   const badge = document.getElementById('loadAvgBadge');
 
-  badge.classList.remove('green', 'orange', 'red');
+  badge.classList.remove('color-success', 'color-warning', 'color-danger');
 
   if (!loads || !cores) {
     document.getElementById('load1Val').textContent = '—';
@@ -986,13 +986,13 @@ function renderLoadAverage(raw, cores) {
     badge.textContent = '';
   } else if (one.rawPct < 70) {
     badge.textContent = '🟢 Système OK';
-    badge.classList.add('green');
+    badge.classList.add('color-success');
   } else if (one.rawPct < 100) {
     badge.textContent = '🟠 Système chargé';
-    badge.classList.add('orange');
+    badge.classList.add('color-warning');
   } else {
     badge.textContent = '🔴 Système surchargé';
-    badge.classList.add('red');
+    badge.classList.add('color-danger');
   }
 }
 
@@ -1011,9 +1011,9 @@ function renderText(json) {
   setupCopy('copyUptime', () => upEl.textContent);
   const upBadge = document.getElementById('uptimeBadge');
   upBadge.className = 'badge';
-  if (upInfo.days > 7) { upBadge.textContent = 'Stable'; upBadge.classList.add('success'); }
-  else if (upInfo.days >= 1) { upBadge.textContent = 'Récemment redémarré'; upBadge.classList.add('warning'); }
-  else { upBadge.textContent = 'Tout juste démarré'; upBadge.classList.add('danger'); }
+  if (upInfo.days > 7) { upBadge.textContent = 'Stable'; upBadge.classList.add('color-success'); }
+  else if (upInfo.days >= 1) { upBadge.textContent = 'Récemment redémarré'; upBadge.classList.add('color-warning'); }
+  else { upBadge.textContent = 'Tout juste démarré'; upBadge.classList.add('color-danger'); }
   const bootTs = json.boot_ts || json.boot_time || null;
   const sinceEl = document.getElementById('uptimeSince');
   if (bootTs) {
@@ -1050,9 +1050,10 @@ function renderText(json) {
   renderCpuTemps(json.cpu?.temperatures);
 
   const badge = document.getElementById('cpuLoadBadge');
+  const colorMap = { green: 'color-success', orange: 'color-warning', red: 'color-danger', blue: 'color-info', yellow: 'color-warning' };
   const color = json.cpu_load_color ? json.cpu_load_color.toLowerCase() : '';
   badge.textContent = json.cpu_load_color?.toUpperCase() || 'N/A';
-  badge.className = 'badge ' + color;
+  badge.className = 'badge ' + (colorMap[color] || '');
 
   renderServices(json.services);
   renderPorts(json.ports);

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1,0 +1,11 @@
+:root {
+  --success: #4caf50;
+  --warning: #ff9800;
+  --danger: #f44336;
+  --info: #2196f3;
+}
+
+.color-success { background: var(--success); color: #fff; }
+.color-warning { background: var(--warning); color: #000; }
+.color-danger  { background: var(--danger); color: #fff; }
+.color-info    { background: var(--info); color: #fff; }


### PR DESCRIPTION
## Summary
- add global color variables and utility classes
- replace hardcoded colors with new vars in audit viewer
- align colorClass utilities in viewer script with variable-based scheme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b19b4c990832db3aaa66e26097c27