### PR TITLE
Fix disk bar text contrast

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -505,12 +505,14 @@ function contrastColor(bg){
 }
 
 function adjustBarValue(valueEl, fillEl, val){
+  let bg;
   if (val >= 20){
-    const bg = getComputedStyle(fillEl).backgroundColor;
-    valueEl.style.color = contrastColor(bg);
+    bg = getComputedStyle(fillEl).backgroundColor;
   } else {
-    valueEl.style.color = '#fff';
+    // For small fills, use the bar background to ensure contrast
+    bg = getComputedStyle(fillEl.parentElement).backgroundColor;
   }
+  valueEl.style.color = contrastColor(bg);
 }
 
 function parseDocker(item){


### PR DESCRIPTION
## Summary
- ensure disk usage bar text contrasts with small fills by sampling bar background

## Testing
- `node --check audits/scripts/viewer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1fdc43cc832d8c67912a141b5f01