### PR TITLE
fix: ensure theme toggle stays visible on mobile

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -414,7 +414,15 @@
     }
 
     @media screen and (max-width: 600px) {
+      .top-bar {
+        padding: 10px;
+      }
       #themeSwitchWrapper {
+        position: fixed;
+        top: 0;
+        right: 0;
+        margin-top: 10px;
+        margin-right: 10px;
         gap: 0.5rem;
       }
       .switch {


### PR DESCRIPTION
## Summary
- keep theme toggle fully visible on small screens
- adjust top bar spacing on narrow viewports

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689b366d3774832dbc7d1ff835885676