### PR TITLE
feat: improve desktop layout

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1172,19 +1172,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const overlay = document.getElementById('menuOverlay');
   const toggle = document.getElementById('menuToggle');
 
-  const updateSidebar = () => {
-    if (window.innerWidth >= 768) {
-      sidebar.classList.add('open');
-    } else {
-      sidebar.classList.remove('open');
-    }
-  };
+  toggle.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
+  });
 
-  toggle.onclick = () => sidebar.classList.toggle('open');
-  overlay.onclick = () => sidebar.classList.remove('open');
-
-  updateSidebar();
-  window.addEventListener('resize', updateSidebar);
+  overlay.addEventListener('click', () => {
+    sidebar.classList.remove('open');
+  });
 });
 
 document.addEventListener('DOMContentLoaded', init);

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -219,6 +219,18 @@
       color: var(--bg);
     }
 
+    @media (min-width: 1024px) {
+      .timeline-wrapper {
+        overflow-x: visible;
+      }
+      .timeline {
+        flex-wrap: wrap;
+      }
+      .time-chip {
+        flex: 1 1 45%;
+      }
+    }
+
     .time-chip:focus-visible {
       outline: 2px solid var(--heading);
       outline-offset: 4px;
@@ -413,10 +425,10 @@
       transform: translateX(24px);
     }
 
-    @media screen and (max-width: 600px) {
-      .top-bar {
-        padding: 10px;
-      }
+  @media screen and (max-width: 600px) {
+    .top-bar {
+      padding: 10px;
+    }
       #themeSwitchWrapper {
         position: fixed;
         top: 0;
@@ -436,8 +448,17 @@
       .switch input:checked + .slider:before {
         transform: translateX(20px);
       }
-      .report-grid { display: flex; }
+    .report-grid { display: flex; }
+  }
+
+  @media (min-width: 1024px) {
+    #themeSwitchWrapper {
+      position: fixed;
+      top: 15px;
+      right: 15px;
+      z-index: 1200;
     }
+  }
 
     .temp-wrapper {
       margin-top: 1rem;
@@ -944,31 +965,29 @@
 
 
 
-#menuOverlay {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.5);
-  z-index: 900;
-}
+  #menuOverlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    z-index: 900;
+  }
 
-@media (max-width: 767px) {
   .sidebar.open ~ #menuOverlay {
     display: block;
   }
-}
 
-main {
-  max-width: 900px;
-  margin: auto;
-  transition: margin-left 0.3s ease;
-}
-
-@media (min-width:768px) {
-  .sidebar.open ~ main {
-    margin-left: 260px;
+  main {
+    max-width: 900px;
+    margin: auto;
   }
-}
+
+  @media (min-width: 1024px) {
+    .sidebar {
+      width: 320px;
+    }
+  }
+


### PR DESCRIPTION
## Summary
- keep theme switch visible on desktop
- switch sidebar to overlay and widen report selector
- simplify menu toggle logic

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b3816f904832d80b95580ea19ae09