### PR TITLE
Add defer to viewer script

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-  <script src="/scripts/viewer.js?v=3"></script>
+  <script src="/scripts/viewer.js?v=3" defer></script>
 </head>
 <body class="theme-dark">
   <header id="topBar" class="top-bar">


### PR DESCRIPTION
## Summary
- defer the viewer script loading to avoid blocking rendering
- ensure JS initializations rely on DOMContentLoaded or run at end of body

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_689b3a996abc832d9802a7f84dc95ef2