### PR TITLE
Fix uptime badge and display issues

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1012,10 +1012,9 @@ function renderText(json) {
   upEl.textContent = upInfo.text;
   setupCopy('copyUptime', () => upEl.textContent);
   const upBadge = document.getElementById('uptimeBadge');
-  upBadge.className = 'badge';
-  if (upInfo.days > 7) { upBadge.textContent = 'Stable'; upBadge.classList.add('color-success'); }
-  else if (upInfo.days >= 1) { upBadge.textContent = 'Récemment redémarré'; upBadge.classList.add('color-warning'); }
-  else { upBadge.textContent = 'Tout juste démarré'; upBadge.classList.add('color-danger'); }
+  if (upBadge) {
+    upBadge.style.display = 'none';
+  }
   const bootTs = json.boot_ts || json.boot_time || null;
   const sinceEl = document.getElementById('uptimeSince');
   if (bootTs) {

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -554,6 +554,7 @@ body {
 .badge.warning, .pill.warning { background:var(--warn); color:#000; }
 .badge.danger,  .pill.danger  { background:var(--crit); color:#fff; }
 
+.network-card { margin-top: var(--gap-4); }
 .network-card .ip-row { display:flex; align-items:center; gap:var(--gap-2); }
 .network-card .ip-row + .ip-row { margin-top:var(--gap-2); }
 .network-card .ip-icon { width:1.25rem; text-align:center; }
@@ -677,7 +678,7 @@ body {
  .mini-card.na { opacity:0.5; }
 
 .progress { position:relative; background:var(--bg-muted); border-radius:var(--radius); height:14px; overflow:hidden; }
-.progress--thin { height:8px; }
+.progress--thin { height:16px; }
 .progress__bar { background:var(--accent); height:100%; border-radius:inherit; width:0%; }
 .progress__value { position:absolute; inset:0; display:grid; place-items:center; font-size:var(--font-sm); font-weight:600; color:var(--text); }
 


### PR DESCRIPTION
## Summary
- remove colored uptime status badge
- prevent load average gauge values from clipping
- add top margin above network addressing card

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4001deb0832db110d7579d796360