### PR TITLE
feat: animate hamburger menu and auto-close on report selection

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -720,6 +720,7 @@ async function selectTime(file) {
     currentFile = file;
     renderText(json);
     setActiveTime(file);
+    if (typeof closeMenu === 'function') closeMenu();
   }
 }
 
@@ -1150,18 +1151,30 @@ async function refreshAudits() {
   }
 }
 
+
+let closeMenu;
+
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   const overlay = document.getElementById('menuOverlay');
   const toggle = document.getElementById('menuToggle');
+  const icon = toggle.querySelector('i');
+
+  closeMenu = () => {
+    sidebar.classList.remove('open');
+    toggle.classList.remove('open');
+    icon.classList.remove('fa-xmark');
+    icon.classList.add('fa-bars');
+  };
 
   toggle.addEventListener('click', () => {
-    sidebar.classList.toggle('open');
+    const isOpen = sidebar.classList.toggle('open');
+    toggle.classList.toggle('open', isOpen);
+    icon.classList.toggle('fa-bars', !isOpen);
+    icon.classList.toggle('fa-xmark', isOpen);
   });
 
-  overlay.addEventListener('click', () => {
-    sidebar.classList.remove('open');
-  });
+  overlay.addEventListener('click', closeMenu);
 });
 
 document.addEventListener('DOMContentLoaded', init);

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -411,6 +411,14 @@ body {
       cursor: pointer;
     }
 
+    .menu-toggle i {
+      transition: transform 0.3s ease;
+    }
+
+    .menu-toggle.open i {
+      transform: rotate(90deg);
+    }
+
     #themeSwitchWrapper {
       display: flex;
       align-items: center;


### PR DESCRIPTION
## Summary
- animate hamburger menu toggle
- close sidebar when selecting latest report or time slot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b442efdcc832da93b8afe03f6b3ea