### PR TITLE
Remove menu button outline on click

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -411,6 +411,15 @@ body {
       cursor: pointer;
     }
 
+    .menu-toggle:focus {
+      outline: none;
+    }
+
+    .menu-toggle:focus-visible {
+      outline: 2px solid var(--heading);
+      outline-offset: 2px;
+    }
+
     .menu-toggle i {
       transition: transform 0.3s ease;
     }


### PR DESCRIPTION
## Summary
- prevent blue outline on menu button and keep keyboard focus styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4598a5d8832d9c16d97d706d8e58