### PR TITLE
Display Docker container stats inside bars

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -606,7 +606,7 @@ function renderDockerList(){
     const cpuColor = colorClassCpu(c.cpu);
     const ramColor = colorClassRam(c.mem);
     const icon = iconFor(c.name);
-    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div><span class="status-badge status-${c.health}">${c.health}</span></div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div></div>${c.memText?`<div class="ram-text">${c.memText}</div>`:''}</div>`;
+    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div><span class="status-badge status-${c.health}">${c.health}</span></div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div><span class="bar-value">${c.cpu}%</span></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div><span class="bar-value">${c.memText || (c.mem + '%')}</span></div></div>`;
     grid.appendChild(card);
     const fills = card.querySelectorAll('.fill');
     requestAnimationFrame(()=>{

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -933,8 +933,9 @@ body {
     .status-running { background: #4caf50; color: #fff; }
     .docker-uptime { font-size: 0.8rem; opacity: 0.8; margin-top: 0.25rem; }
     .docker-bars { margin-top: 0.5rem; display: flex; flex-direction: column; gap: 0.25rem; }
-    .bar-outer { height: 8px; background: #444; border-radius: 4px; overflow: hidden; }
-    .bar-outer .fill { height: 100%; width: 0; transition: width 0.3s ease; }
+    .bar-outer { position: relative; height: 16px; background: var(--bar-bg); border-radius: 4px; overflow: hidden; }
+    .bar-outer .fill { position: absolute; top: 0; left: 0; bottom: 0; width: 0; transition: width 0.3s ease; }
+    .bar-outer .bar-value { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: var(--font-sm); font-weight: 600; color: var(--text); text-shadow: 0 0 2px var(--bg); pointer-events: none; }
     .ram-text { font-size: 0.75rem; text-align: center; }
 
     .bar-temp { height: 14px; }


### PR DESCRIPTION
## Summary
- show CPU and RAM usage values directly inside Docker container bars
- style bar elements for readable text in dark or light themes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b47948a4c832d8d4c898a63880d17