### PR TITLE
Clean up port parsing in audit script

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -55,7 +55,8 @@ TOP_CPU=$(ps -eo pid,comm,%cpu,%mem --sort=-%cpu | head -n 6 | jq -Rn '[inputs |
 TOP_MEM=$(ps -eo pid,comm,%mem,%cpu --sort=-%mem | head -n 6 | jq -Rn '[inputs | split(" ") | map(select(length > 0)) | select(length >= 4) | {"pid": .[0], "cmd": .[1], "mem": .[2], "cpu": .[3]}]')
 
 # 🌐 Ports ouverts
-PORTS=$(ss -tuln | awk 'NR>1 {print $1, $5}' | jq -Rn '[inputs | split(" ") | select(length == 2) | {"proto": .[0], "port": .[1]}]')
+PORTS=$(ss -tuln | awk 'NR>1 {print $1, $5}' \
+  | jq -Rn '[inputs | split(" ") | map(select(length>0)) | select(length==2) | {"proto": .[0], "port": .[1]}]')
 
 # 📦 Conversion d'unités en octets
 to_bytes() {


### PR DESCRIPTION
## Summary
- Sanitize `ss` output parsing to drop empty fields before building `proto`/`port` pairs

## Testing
- `shellcheck generate-audit-json.sh`
- `./generate-audit-json.sh` *(fails: `mpstat`, `bc`, `ss` commands not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4acc850c832d90e66c9f1a732a11