### PR TITLE
Handle missing Docker health in viewer

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -650,11 +650,13 @@ function renderDockerList(){
     const card = document.createElement('div');
     card.className = 'docker-card';
     card.tabIndex = 0;
-    card.title = `CPU ${c.cpu}% — RAM ${c.mem}% — Status ${c.health}`;
+    const health = c.health ?? '';
+    card.title = `CPU ${c.cpu}% — RAM ${c.mem}%${health ? ` — Status ${health}` : ''}`;
     const cpuColor = colorClassCpu(c.cpu);
     const ramColor = colorClassRam(c.mem);
     const icon = iconFor(c.name);
-    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div><span class="status-badge status-${c.health}">${c.health}</span></div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div><span class="bar-value">${c.cpu}%</span></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div><span class="bar-value">${c.memText || (c.mem + '%')}</span></div></div>`;
+    const badge = health ? `<span class="status-badge status-${health}">${health}</span>` : '';
+    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div>${badge}</div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div><span class="bar-value">${c.cpu}%</span></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div><span class="bar-value">${c.memText || (c.mem + '%')}</span></div></div>`;
     grid.appendChild(card);
     const fills = card.querySelectorAll('.fill');
     requestAnimationFrame(()=>{


### PR DESCRIPTION
## Summary
- avoid showing undefined Docker health by defaulting to empty string
- skip health status text and class when health data is absent

## Testing
- `node --check audits/scripts/viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_689b4cd71e08832db22398e091037e73