### PR TITLE
Fix day selection menu behavior and reorder report menu

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -40,17 +40,17 @@
           <small id="latestInfo" class="subinfo"></small>
         </button>
 
-        <div class="timeline-wrapper">
-          <div id="timeTimeline" class="timeline" aria-live="polite"></div>
-        </div>
-
-        <div id="selectorStatus" aria-live="polite"></div>
-
         <div class="day-control" role="group" aria-label="Choisir un jour">
           <button id="dayToday" class="seg">Aujourd'hui</button>
           <button id="dayYesterday" class="seg">Hier</button>
           <button id="dayCalendar" class="seg" aria-label="Choisir une date" title="Choisir une date"><i class="fa-solid fa-calendar"></i></button>
           <input type="date" id="datePicker" class="sr-only" />
+        </div>
+
+        <div id="selectorStatus" aria-live="polite"></div>
+
+        <div class="timeline-wrapper">
+          <div id="timeTimeline" class="timeline" aria-live="polite"></div>
         </div>
       </div>
 

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -756,7 +756,6 @@ function populateDay(day) {
   showStatus('');
   renderTimeline(list);
   const last = list[list.length - 1];
-  setActiveTime(last.file);
   return last.file;
 }
 
@@ -1135,8 +1134,7 @@ async function init() {
     document.getElementById('datePicker').value = day;
     selectedDate = day;
     updateDayButtons();
-    const file = populateDay(day);
-    if (file) selectTime(file);
+    populateDay(day);
   });
 
   document.getElementById('dayYesterday').addEventListener('click', () => {
@@ -1144,8 +1142,7 @@ async function init() {
     document.getElementById('datePicker').value = day;
     selectedDate = day;
     updateDayButtons();
-    const file = populateDay(day);
-    if (file) selectTime(file);
+    populateDay(day);
   });
 
   document.getElementById('dayCalendar').addEventListener('click', () => {
@@ -1157,8 +1154,7 @@ async function init() {
   document.getElementById('datePicker').addEventListener('change', () => {
     selectedDate = document.getElementById('datePicker').value;
     updateDayButtons();
-    const file = populateDay(selectedDate);
-    if (file) selectTime(file);
+    populateDay(selectedDate);
   });
 
 

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -186,17 +186,18 @@ body {
     @media (min-width: 601px) {
       .report-grid {
         display: grid;
-        grid-template-columns: 1fr auto;
+        grid-template-columns: 1fr;
         grid-template-areas:
-          "btn day"
-          "timeline timeline"
-          "status status";
+          "btn"
+          "day"
+          "status"
+          "timeline";
         gap: 0.5rem;
       }
       #btnLatest { grid-area: btn; }
-      .timeline-wrapper { grid-area: timeline; }
+      .day-control { grid-area: day; }
       #selectorStatus { grid-area: status; }
-      .day-control { grid-area: day; justify-self: end; }
+      .timeline-wrapper { grid-area: timeline; }
     }
 
     .day-control {


### PR DESCRIPTION
## Summary
- Do not auto-load a report when choosing today, yesterday, or a calendar date
- Reorder report menu: latest report button, day selector, then available times
- Adjust responsive layout for new menu order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4e481c50832db740e16d9b892916