### PR TITLE
Add usage guide and basic test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS Instructions
+
+- Run `./tests/run.sh` after making changes to code or docs.
+- Keep documentation in Markdown format with lines wrapped at roughly 120 characters.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make sure these commands are available on the machine where you run the script.
 
 ## Generating an audit
 
-Edit the `BASE_DIR` variable near the top of `generate-audit-json.sh` to point to the directory where reports should be stored. Then run:
+The script stores reports under `/home/damswallace/docker/audits-nginx/audits` by default. You can override the location by setting the `BASE_DIR` environment variable before running:
 
 ```bash
 ./generate-audit-json.sh
@@ -43,6 +43,18 @@ Open `http://<container-ip>/` in a browser to view the dashboard. The frontend (
 ├── generate-audit-json.sh # Bash script to create audit_*.json files
 ├── docker-compose.yaml    # Nginx setup for serving the reports
 └── nginx.conf             # Basic Nginx configuration
+```
+
+## Documentation
+
+Additional usage instructions are available in the [docs](docs/USAGE.md) directory.
+
+## Testing
+
+Run the provided test script to generate a sample report and validate its JSON structure:
+
+```bash
+./tests/run.sh
 ```
 
 ## License

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,33 @@
+# Audit Server Documentation
+
+This document provides extra details on how to use the audit script and serve the resulting reports.
+
+## Generating reports
+
+The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override this location by setting the `BASE_DIR` environment variable:
+
+```bash
+BASE_DIR=/tmp/audits ./generate-audit-json.sh
+```
+
+Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of available reports.
+
+## Serving the reports
+
+Use the provided `docker-compose.yaml` file to expose the `audits` directory with Nginx:
+
+```bash
+docker-compose up -d
+```
+
+Open the container's address in a browser to view the dashboard.
+
+## Running tests
+
+A minimal test script ensures the audit generator produces valid JSON output. Execute:
+
+```bash
+./tests/run.sh
+```
+
+The test creates a temporary audit directory, runs the generator and validates the resulting JSON file.

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -8,8 +8,8 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 TIMESTAMP=$(date "+%Y-%m-%d_%H-%M")
 HUMAN_DATE=$(date "+%d/%m/%Y à %H:%M")
 
-# 📁 Dossiers
-BASE_DIR="/home/damswallace/docker/audits-nginx/audits"
+# 📁 Dossiers (modifiable avec la variable d'environnement BASE_DIR)
+BASE_DIR="${BASE_DIR:-/home/damswallace/docker/audits-nginx/audits}"
 ARCHIVE_DIR="$BASE_DIR/archives"
 OUTPUT_FILE="${ARCHIVE_DIR}/audit_${TIMESTAMP}.json"
 mkdir -p "$ARCHIVE_DIR"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+tmp_dir=$(mktemp -d)
+BASE_DIR="$tmp_dir" ./generate-audit-json.sh >/tmp/test_audit.log
+archive_dir="$tmp_dir/archives"
+file=$(ls "$archive_dir"/audit_*.json | head -n 1)
+
+if [ ! -f "$file" ]; then
+  echo "No audit file generated" >&2
+  exit 1
+fi
+
+jq empty "$file"
+
+echo "Test passed: audit JSON generated at $file"


### PR DESCRIPTION
## Summary
- Allow overriding audit output directory via `BASE_DIR` environment variable
- Expand README with documentation and testing instructions
- Add detailed usage guide under `docs/`
- Include basic test to ensure JSON output generation

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b50d80974832d95df15ee61697f48