### PR TITLE
Add GPU monitoring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ The `generate-audit-json.sh` script relies on a few common utilities:
 - `jq` for JSON formatting
 - `sensors` for temperature readings (optional)
 - `curl` to retrieve the public IP address
+- `intel-gpu-tools` or `nvidia-smi` to collect GPU usage (optional)
 
 Make sure these commands are available on the machine where you run the script.
+
+If `intel_gpu_top` or `nvidia-smi` is present, the audit will also report GPU utilisation. Intel GPUs require running the script as
+root with `debugfs` mounted (usually under `/sys/kernel/debug`).
 
 ## Generating an audit
 

--- a/audits/index.html
+++ b/audits/index.html
@@ -147,6 +147,9 @@
   <h2><i class="fa-solid fa-temperature-three-quarters heading-icon"></i>Températures CPU</h2>
   <div id="tempsContainer" class="proc-list"></div>
 
+  <h2><i class="fa-solid fa-chart-line heading-icon"></i>GPU</h2>
+  <div id="gpuContainer" class="memory-container"></div>
+
   <h2><i class="fa-solid fa-memory heading-icon"></i>Mémoire RAM</h2>
   <div id="memoryContainer" class="memory-container"></div>
 

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -85,6 +85,20 @@ function colorClassDisk(v){
   return 'color-danger';
 }
 
+function colorClassGpu(v){
+  const val = Number(v);
+  if (val < 40) return 'color-success';
+  if (val < 70) return 'color-warning';
+  return 'color-danger';
+}
+
+function colorClassGpuMem(v){
+  const val = Number(v);
+  if (val < 40) return 'color-info';
+  if (val < 70) return 'color-warning';
+  return 'color-danger';
+}
+
 function parseSizeToBytes(val){
   if (val == null) return null;
   if (typeof val === 'number' && !isNaN(val)) return val;
@@ -848,6 +862,49 @@ function renderCpuTemps(temps){
   });
 }
 
+function renderGpu(gpu){
+  const container = document.getElementById('gpuContainer');
+  container.innerHTML = '';
+  if(!gpu){
+    container.innerHTML = '<div class="empty">Aucune donnée GPU</div>';
+    return;
+  }
+  const usage = Number(gpu.usage_pct);
+  const memUsedBytes = parseSizeToBytes(gpu.mem_used_bytes ?? gpu.mem_used);
+  const memTotalBytes = parseSizeToBytes(gpu.mem_total_bytes ?? gpu.mem_total);
+  const memPct = (memUsedBytes != null && memTotalBytes) ? (memUsedBytes / memTotalBytes) * 100 : null;
+  const memPctStr = memPct != null ? (memPct < 10 ? memPct.toFixed(1) : Math.round(memPct)) : 'N/A';
+  const memText = memPct != null ? `${formatBytes(memUsedBytes)} / ${formatBytes(memTotalBytes)}` : 'Données mémoire indisponibles';
+  const vendor = gpu.vendor ? ` (${gpu.vendor})` : '';
+  const card = document.createElement('div');
+  card.className = 'disk-card';
+  card.innerHTML = `
+    <div class="proc-row">
+      <span class="proc-name">GPU${vendor}</span>
+      <div class="proc-bars">
+        <div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${usage}">
+          <span class="fill ${colorClassGpu(usage)}" style="width:0"></span>
+          <span class="value">${usage}%</span>
+        </div>
+        ${memPct != null ? `<div class="bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${memPctStr}"><span class="fill ${colorClassGpuMem(memPct)}" style="width:0"></span><span class="value">${memPctStr}%</span></div>` : ''}
+      </div>
+    </div>
+    <div class="ram-text">Mémoire : ${memText}</div>`;
+  container.appendChild(card);
+  const fills = card.querySelectorAll('.bar .fill');
+  const values = card.querySelectorAll('.bar .value');
+  requestAnimationFrame(()=>{
+    if(fills[0]){
+      fills[0].style.width = usage + '%';
+      adjustBarValue(values[0], fills[0], usage);
+    }
+    if(memPct != null && fills[1]){
+      fills[1].style.width = memPct + '%';
+      adjustBarValue(values[1], fills[1], memPct);
+    }
+  });
+}
+
 function renderMemory(mem){
   const container = document.getElementById('memoryContainer');
   container.innerHTML = '';
@@ -1086,9 +1143,10 @@ function renderText(json) {
 
   renderLoadAverage(json.load_average, json.cpu?.cores);
   renderCpuCores(json.cpu?.usage);
+  renderCpuTemps(json.cpu?.temperatures);
+  renderGpu(json.gpu);
   renderMemory(json.memory?.ram);
   renderDisks(json.disks);
-  renderCpuTemps(json.cpu?.temperatures);
 
   renderServices(json.services);
   renderPorts(json.ports);

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12,6 +12,9 @@ BASE_DIR=/tmp/audits ./generate-audit-json.sh
 
 Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of available reports.
 
+If `intel_gpu_top` or `nvidia-smi` is installed, the script also includes GPU usage. Intel GPUs need root access and the `debugfs`
+filesystem mounted.
+
 ## Serving the reports
 
 Use the provided `docker-compose.yaml` file to expose the `audits` directory with Nginx:

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -47,6 +47,26 @@ cpu_color="green"
 if (( $(echo "$cpu_total_usage > 60" | bc -l) )); then cpu_color="orange"; fi
 if (( $(echo "$cpu_total_usage > 85" | bc -l) )); then cpu_color="red"; fi
 
+# 🎮 GPU (Intel/Nvidia)
+GPU_DATA="null"
+if command -v intel_gpu_top >/dev/null 2>&1; then
+  GPU_JSON=$(timeout 5 intel_gpu_top -J 2>/dev/null || true)
+  if [[ -n "$GPU_JSON" ]]; then
+    GPU_USAGE=$(echo "$GPU_JSON" | jq '[.engines[].busy] | add / length' 2>/dev/null)
+    GPU_DATA=$(jq -n --arg vendor "intel" --argjson usage "${GPU_USAGE:-0}" '{vendor:$vendor,usage_pct:$usage,mem_total_bytes:null,mem_used_bytes:null}')
+  fi
+elif command -v nvidia-smi >/dev/null 2>&1; then
+  line=$(nvidia-smi --query-gpu=utilization.gpu,memory.total,memory.used --format=csv,noheader,nounits 2>/dev/null | head -n 1)
+  if [[ -n "$line" ]]; then
+    util=$(echo "$line" | cut -d',' -f1 | tr -d ' ')
+    mem_total=$(echo "$line" | cut -d',' -f2 | tr -d ' ')
+    mem_used=$(echo "$line" | cut -d',' -f3 | tr -d ' ')
+    mem_total_bytes=$((mem_total*1024*1024))
+    mem_used_bytes=$((mem_used*1024*1024))
+    GPU_DATA=$(jq -n --arg vendor "nvidia" --argjson usage "$util" --argjson mem_total "$mem_total_bytes" --argjson mem_used "$mem_used_bytes" '{vendor:$vendor,usage_pct:$usage,mem_total_bytes:$mem_total,mem_used_bytes:$mem_used}')
+  fi
+fi
+
 # 🛠 Services actifs
 SERVICES=$(systemctl list-units --type=service --state=running --no-pager --no-legend | awk '{print $1}' | jq -R . | jq -s .)
 
@@ -132,6 +152,7 @@ jq -n \
   --argjson cpu_cores "$CPU_CORES" \
   --argjson cpu_usage "$cpu_data" \
   --arg cpu_color "$cpu_color" \
+  --argjson gpu "$GPU_DATA" \
   --argjson services "$SERVICES" \
   --argjson top_cpu "$TOP_CPU" \
   --argjson top_mem "$TOP_MEM" \
@@ -155,6 +176,7 @@ jq -n \
       usage: $cpu_usage,
       temperatures: $temp_cores
     },
+    gpu: $gpu,
     cpu_load_color: $cpu_color,
     services: $services,
     top_cpu: $top_cpu,


### PR DESCRIPTION
## Summary
- collect GPU metrics using `intel_gpu_top` or `nvidia-smi`
- display GPU utilisation and memory in dashboard with color cues
- document optional GPU requirements and root access for Intel GPUs

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b52950524832d956d0ea4c7cca205