### PR TITLE
Add web-based report management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Audit Server
 
-This project provides a lightweight way to collect and view system audit reports. A Bash script gathers metrics such as CPU usage, memory consumption, open ports and running services, then writes the results to JSON files. A small web frontend served by Nginx lets you browse these reports over time.
+This project provides a lightweight way to collect and view system audit reports. A Bash script
+gathers metrics such as CPU usage, memory consumption, open ports and running services, then
+writes the results to JSON files. A small web frontend served by Nginx lets you browse these
+reports over time.
 
 ## Requirements
 
@@ -15,23 +18,33 @@ Make sure these commands are available on the machine where you run the script.
 
 ## Generating an audit
 
-The script stores reports under `/home/damswallace/docker/audits-nginx/audits` by default. You can override the location by setting the `BASE_DIR` environment variable before running:
+The script stores reports under `/home/damswallace/docker/audits-nginx/audits` by default. You can
+override the location by setting the `BASE_DIR` environment variable before running:
 
 ```bash
 ./generate-audit-json.sh
 ```
 
-Each execution creates an `audit_YYYY-MM-DD_HH-MM.json` file inside `archives/` and updates `index.json` with the list of available reports. You can schedule the script via cron to capture snapshots at regular intervals.
+Each execution creates an `audit_YYYY-MM-DD_HH-MM.json` file inside `archives/` and updates
+`index.json` with the list of available reports. You can schedule the script via cron to capture
+snapshots at regular intervals.
+
+## Managing reports
+
+Run the lightweight Node server and use the web interface to create or remove audits:
+
+```bash
+node server.js
+```
+
+The dashboard exposes buttons to generate a fresh report or delete the currently selected one.
+Each action updates `archives/index.json` automatically.
 
 ## Serving the reports
 
-The `docker-compose.yaml` file starts an Nginx container that exposes the `audits` directory as static files. Launch it with:
-
-```bash
-docker-compose up -d
-```
-
-Open `http://<container-ip>/` in a browser to view the dashboard. The frontend (`audits/index.html` and `audits/scripts/viewer.js`) reads the JSON files and displays graphs and statistics using Chart.js.
+`server.js` serves the `audits` directory and provides the `/api/reports` endpoint used by the UI.
+Start it with the command above and open `http://localhost:8080/` in a browser. The included
+`docker-compose.yaml` can still be used if you prefer an Nginx setup.
 
 ## Directory structure
 

--- a/audits/index.html
+++ b/audits/index.html
@@ -52,6 +52,10 @@
         <div class="timeline-wrapper">
           <div id="timeTimeline" class="timeline" aria-live="polite"></div>
         </div>
+        <div class="report-actions">
+          <button id="btnGenerate" class="btn">Générer un rapport</button>
+          <button id="btnDelete" class="btn color-danger" disabled>Supprimer le rapport</button>
+        </div>
       </div>
 
       <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -770,6 +770,8 @@ async function selectTime(file) {
     renderText(json);
     setActiveTime(file);
     if (typeof closeMenu === 'function') closeMenu();
+    const del = document.getElementById('btnDelete');
+    if (del) del.disabled = false;
   }
 }
 
@@ -1221,6 +1223,43 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   overlay.addEventListener('click', closeMenu);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+  const gen = document.getElementById('btnGenerate');
+  const del = document.getElementById('btnDelete');
+  if (gen) {
+    gen.addEventListener('click', async () => {
+      showStatus('Génération…', 'loading');
+      try {
+        const res = await fetch('/api/reports', {method: 'POST'});
+        if (!res.ok) throw new Error('fail');
+        await refreshAudits();
+      } catch (err) {
+        alert('Échec de la génération');
+      } finally {
+        showStatus('');
+      }
+    });
+  }
+  if (del) {
+    del.addEventListener('click', async () => {
+      if (!currentFile) return;
+      if (!confirm('Supprimer ce rapport ?')) return;
+      showStatus('Suppression…', 'loading');
+      try {
+        const res = await fetch(`/api/reports/${currentFile}`, {method: 'DELETE'});
+        if (!res.ok) throw new Error('fail');
+        currentFile = null;
+        del.disabled = true;
+        await refreshAudits();
+      } catch (err) {
+        alert('Échec de la suppression');
+      } finally {
+        showStatus('');
+      }
+    });
+  }
 });
 
 document.addEventListener('DOMContentLoaded', init);

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,7 +4,9 @@ This document provides extra details on how to use the audit script and serve th
 
 ## Generating reports
 
-The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override this location by setting the `BASE_DIR` environment variable:
+The `generate-audit-json.sh` script collects system information and writes it as JSON files. By
+default, reports are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override
+this location by setting the `BASE_DIR` environment variable:
 
 ```bash
 BASE_DIR=/tmp/audits ./generate-audit-json.sh
@@ -12,15 +14,21 @@ BASE_DIR=/tmp/audits ./generate-audit-json.sh
 
 Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of available reports.
 
-## Serving the reports
+## Managing reports
 
-Use the provided `docker-compose.yaml` file to expose the `audits` directory with Nginx:
+Start the Node server to manage audits directly from the web interface:
 
 ```bash
-docker-compose up -d
+node server.js
 ```
 
-Open the container's address in a browser to view the dashboard.
+The dashboard offers buttons to generate a new report or delete the current one. All updates are
+reflected in `archives/index.json`.
+
+## Serving the reports
+
+`server.js` serves the static files under `audits` and exposes the `/api/reports` endpoint. After
+starting it, open the reported address in a browser to view the dashboard.
 
 ## Running tests
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,94 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+const { spawn } = require('child_process');
+
+const auditsDir = path.join(__dirname, 'audits');
+const archivesDir = path.join(auditsDir, 'archives');
+const scriptPath = path.join(__dirname, 'generate-audit-json.sh');
+
+function send(res, status, body, type = 'text/plain') {
+  res.writeHead(status, { 'Content-Type': type });
+  res.end(body);
+}
+
+function serveStatic(req, res) {
+  let p = url.parse(req.url).pathname;
+  if (p === '/') p = '/index.html';
+  const filePath = path.join(auditsDir, path.normalize(p).replace(/^\/+/, ''));
+  if (!filePath.startsWith(auditsDir)) return send(res, 403, 'Forbidden');
+  fs.readFile(filePath, (err, data) => {
+    if (err) return send(res, 404, 'Not found');
+    const ext = path.extname(filePath).toLowerCase();
+    const type = {
+      '.html': 'text/html; charset=utf-8',
+      '.js': 'application/javascript; charset=utf-8',
+      '.css': 'text/css; charset=utf-8',
+      '.json': 'application/json; charset=utf-8',
+      '.ico': 'image/x-icon'
+    }[ext] || 'text/plain; charset=utf-8';
+    send(res, 200, data, type);
+  });
+}
+
+function updateIndex(res) {
+  fs.readdir(archivesDir, (err, files) => {
+    if (err) return send(res, 500, 'read err');
+    const audits = files
+      .filter(f => /^audit_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}\.json$/.test(f))
+      .sort()
+      .reverse();
+    fs.writeFile(
+      path.join(archivesDir, 'index.json'),
+      JSON.stringify(audits, null, 2),
+      wErr => {
+        if (wErr) return send(res, 500, 'write err');
+        send(res, 200, JSON.stringify({ ok: true }), 'application/json');
+      }
+    );
+  });
+}
+
+function handleApi(req, res) {
+  const parsed = url.parse(req.url);
+  if (req.method === 'GET' && parsed.pathname === '/api/reports') {
+    fs.readFile(path.join(archivesDir, 'index.json'), (err, data) => {
+      if (err) return send(res, 500, 'index error');
+      send(res, 200, data, 'application/json');
+    });
+    return;
+  }
+  if (req.method === 'POST' && parsed.pathname === '/api/reports') {
+    const child = spawn(scriptPath, [], {
+      env: { ...process.env, BASE_DIR: auditsDir }
+    });
+    child.on('exit', code => {
+      if (code === 0) send(res, 200, JSON.stringify({ ok: true }), 'application/json');
+      else send(res, 500, 'script error');
+    });
+    return;
+  }
+  if (req.method === 'DELETE' && parsed.pathname.startsWith('/api/reports/')) {
+    const file = path.basename(parsed.pathname.replace('/api/reports/', ''));
+    if (!/^audit_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}\.json$/.test(file))
+      return send(res, 400, 'bad name');
+    fs.unlink(path.join(archivesDir, file), err => {
+      if (err) return send(res, 404, 'not found');
+      updateIndex(res);
+    });
+    return;
+  }
+  send(res, 404, 'Not found');
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/api/')) return handleApi(req, res);
+  serveStatic(req, res);
+});
+
+const PORT = process.env.PORT || 8080;
+server.listen(PORT, () => {
+  console.log(`Audit server listening on ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- expose `/api/reports` in new Node server for listing, generating and deleting audit JSON files
- add web UI buttons to trigger report creation and removal
- document Node server usage for managing reports in the dashboard

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b6e8b4aa4832d990b8bb12667a0ca