### PR TITLE
Refine memory viewer labels

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -88,7 +88,7 @@ function colorClassDisk(v){
 function parseSizeToBytes(val){
   if (val == null) return null;
   if (typeof val === 'number' && !isNaN(val)) return val;
-  const str = String(val).trim().replace(',', '.');
+  const str = String(val).trim().replace(/,/g, '.');
   const m = str.match(/^(\d+(?:\.\d+)?)(?:\s*(B|[KMGT]iB?|[KMGT]i))?$/i);
   if (!m) return null;
   const num = parseFloat(m[1]);
@@ -964,21 +964,19 @@ function renderMemory(model){
       segEl.className = `seg ${seg.cls}`;
       segEl.style.width = pct + '%';
       segEl.dataset.tip = `${seg.label} : ${formatGi(seg.val)} (${pctStr}%)`;
-      const label = document.createElement('span');
-      label.className = 'label';
-      label.textContent = `${formatGi(seg.val)} (${pctStr}%)`;
-      segEl.appendChild(label);
       bar.appendChild(segEl);
-      if (pct < 12){
-        label.classList.add('hidden');
-        const item = document.createElement('span');
-        item.className = `legend-item ${seg.cls}`;
-        item.innerHTML = `<span class="dot"></span>${seg.label} : ${formatGi(seg.val)} (${pctStr}%)`;
-        legend.appendChild(item);
-      } else {
-        requestAnimationFrame(()=>adjustBarValue(label, segEl, pct));
-      }
+      const item = document.createElement('span');
+      item.className = `legend-item ${seg.cls}`;
+      item.innerHTML = `<span class="dot"></span>${seg.label} : ${formatGi(seg.val)} (${pctStr}%)`;
+      legend.appendChild(item);
     });
+    if (info.usedEffectiveBytes > 0){
+      const pctStr = Math.round(info.seg.usedPct);
+      const center = document.createElement('div');
+      center.className = 'bar-label';
+      center.textContent = `Utilisée réelle : ${formatGi(info.usedEffectiveBytes)} (${pctStr} %)`;
+      bar.appendChild(center);
+    }
     legend.classList.toggle('hidden', !legend.childElementCount);
 
     const badgeData = [
@@ -1029,7 +1027,11 @@ function renderMemory(model){
       segEl.dataset.tip = `${seg.label} : ${formatGi(seg.val)} (${pctStr}%)`;
       const label = document.createElement('span');
       label.className = 'label';
-      label.textContent = `${formatGi(seg.val)} (${pctStr}%)`;
+      if (info.usedBytes === 0 && seg.label === 'Libre') {
+        label.textContent = `Libre : ${formatGi(seg.val)} (100 %)`;
+      } else {
+        label.textContent = `${formatGi(seg.val)} (${pctStr}%)`;
+      }
       segEl.appendChild(label);
       bar.appendChild(segEl);
       if (pct < 12){

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -643,6 +643,7 @@ body {
     .mem .percent.warn { color: var(--warn); }
     .mem .percent.crit { color: var(--crit); }
     .mem .bar {
+      position: relative;
       display: flex;
       height: 1.5rem;
       background: var(--bar-bg);
@@ -663,6 +664,18 @@ body {
     .mem .seg-cache { background: var(--chip-bg); }
     .mem .seg-free { background: var(--bar-bg); }
     .mem .seg .label.hidden { display: none; }
+    .mem .bar-label {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--font-sm);
+      font-weight: 600;
+      color: var(--text);
+      text-shadow: 0 0 2px var(--bg);
+      pointer-events: none;
+    }
     .mem .bar-legend {
       display: flex;
       flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Normalize size parsing to handle decimal commas
- Show real RAM usage as centered label and list segments in legend
- Display "Libre" message when swap is fully free

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c64a97cb0832d9c9e89cc0ea07f47