### PR TITLE
Refactor header and unify card copy buttons

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -17,6 +17,13 @@
   <body data-theme="dark">
   <header id="topBar" class="top-bar">
     <button id="menuToggle" class="menu-toggle"><i class="fa-solid fa-bars"></i></button>
+    <div class="top-brand">
+      <div class="brand-line">
+        <i class="fa-solid fa-brain" aria-hidden="true"></i>
+        <span class="brand-title">Audit Serveur DW</span>
+      </div>
+      <p id="hostname" class="brand-host">-</p>
+    </div>
     <div id="themeSwitchWrapper">
       <i id="themeIcon" class="fas fa-moon theme-icon"></i>
       <label class="switch">
@@ -61,20 +68,12 @@
   <div id="menuOverlay"></div>
 
   <main>
-    <section class="intro">
-      <div class="intro-header">
-        <i class="fa-solid fa-brain intro-icon" aria-hidden="true"></i>
-        <div class="intro-text">
-          <h1 class="intro-title">Audit Serveur DW</h1>
-          <p id="hostname" class="intro-subtitle">-</p>
-        </div>
-      </div>
-
-      <div class="info-grid">
+    <section class="section-wrap">
+      <div class="cards">
         <div class="info-card card" id="generatedCard" aria-labelledby="generatedTitle">
           <div class="card-head">
             <div class="card-title card__title" id="generatedTitle"><i class="fa-solid fa-calendar-day"></i><span>Date de génération</span></div>
-            <button id="copyGenerated" class="copy-icon" title="Copier la date" aria-label="Copier la date"><i class="fa-regular fa-copy"></i></button>
+            <button id="copyGenerated" class="copy-btn" title="Copier la date" aria-label="Copier la date"><i class="fa-regular fa-copy"></i></button>
           </div>
           <div id="generatedValue" class="card-main">--</div>
           <div class="card-meta card__meta"><span id="tzBadge" class="badge"></span></div>
@@ -83,15 +82,14 @@
           <div class="card-head">
             <div class="card-title card__title" id="uptimeTitle"><i class="fa-solid fa-clock"></i><span>Temps de fonctionnement</span></div>
             <span id="uptimeBadge" class="badge"></span>
-            <button id="copyUptime" class="copy-icon" title="Copier la durée" aria-label="Copier la durée"><i class="fa-regular fa-copy"></i></button>
+            <button id="copyUptime" class="copy-btn" title="Copier la durée" aria-label="Copier la durée"><i class="fa-regular fa-copy"></i></button>
           </div>
           <div id="uptimeValue" class="card-main">--</div>
           <div id="uptimeSince" class="card-meta card__meta"></div>
         </div>
       </div>
-    </section>
 
-    <div class="info-card card network-card" id="networkCard" aria-labelledby="networkTitle">
+      <div class="info-card card network-card" id="networkCard" aria-labelledby="networkTitle">
     <div class="card-head">
       <div class="card-title card__title" id="networkTitle"><i class="fa-solid fa-network-wired"></i><span>Adressage réseau</span></div>
     </div>
@@ -103,7 +101,7 @@
             <span id="ipLocal" class="ip-value">N/A</span>
           </span>
           <span id="netBadge" class="badge pill"></span>
-          <button id="copyIpLocal" class="copy-icon" title="Copier l'IP locale" aria-label="Copier l'IP locale"><i class="fa-regular fa-copy"></i></button>
+          <button id="copyIpLocal" class="copy-btn" title="Copier l'IP locale" aria-label="Copier l'IP locale"><i class="fa-regular fa-copy"></i></button>
         </div>
         <div class="ip-row ip-public">
           <i class="fa-solid fa-globe ip-icon" aria-hidden="true"></i>
@@ -112,10 +110,11 @@
             <span id="ipPublic" class="ip-value">N/A</span>
           </span>
           <span id="ispBadge" class="badge pill"></span>
-          <button id="copyIpPublic" class="copy-icon" title="Copier l'IP externe" aria-label="Copier l'IP externe"><i class="fa-regular fa-copy"></i></button>
+          <button id="copyIpPublic" class="copy-btn" title="Copier l'IP externe" aria-label="Copier l'IP externe"><i class="fa-regular fa-copy"></i></button>
         </div>
     </div>
-  </div>
+      </div>
+    </section>
 
   <h2><i class="fa-solid fa-gauge-high heading-icon"></i>Charge moyenne</h2>
   <div id="loadAvg" class="load-container">

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -8,6 +8,7 @@
   --gap-3: 16px;
   --gap-4: 24px;
   --gap-5: 32px;
+  --space-lg: var(--gap-4);
   --font-sm: 12px;
   --font-md: 14px;
   --font-lg: 16px;
@@ -427,20 +428,28 @@ h1 {
     }
 
     .copy-btn {
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      background: #444;
-      color: #fff;
+      background: none;
       border: none;
-      padding: 5px 8px;
-      border-radius: 4px;
+      color: var(--text-muted);
+      border-radius: 8px;
+      padding: 4px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       cursor: pointer;
-      font-size: 0.8rem;
-      transition: background 0.3s ease;
+      transition: background 0.2s ease, color 0.2s ease;
     }
     .copy-btn:hover {
-      background: #666;
+      background: var(--heading);
+      color: var(--bg);
+    }
+    .copy-btn:focus-visible {
+      outline: 2px solid var(--heading);
+      outline-offset: 2px;
+    }
+    .copy-btn.small {
+      padding: 2px 4px;
+      font-size: var(--font-sm);
     }
 
     .top-bar {
@@ -448,12 +457,36 @@ h1 {
       top: 0;
       left: 0;
       width: 100%;
-      display: flex;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: auto 1fr auto;
       align-items: center;
       background: var(--block-bg);
       padding: 0.5rem 1rem;
       z-index: 1100;
+    }
+
+    .top-brand {
+      justify-self: center;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-1);
+    }
+
+    .brand-line {
+      display: flex;
+      align-items: center;
+      gap: var(--gap-2);
+      justify-content: center;
+    }
+
+    .brand-line i { font-size: 1.5rem; }
+    .brand-title { font-weight: 600; }
+
+    .brand-host {
+      margin: 0;
+      font-size: var(--font-md);
+      opacity: 0.7;
     }
 
     .menu-toggle {
@@ -536,35 +569,11 @@ h1 {
     .top-bar {
       padding: 10px;
     }
-      #themeSwitchWrapper {
-        position: fixed;
-        top: 0;
-        right: 0;
-        margin-top: 10px;
-        margin-right: 10px;
-        gap: 0.5rem;
-      }
-      .switch {
-        width: 40px;
-        height: 20px;
-      }
-      .slider:before {
-        height: 14px;
-        width: 14px;
-      }
-      .switch input:checked + .slider:before {
-        transform: translateX(20px);
-      }
+    #themeSwitchWrapper { gap: 0.5rem; }
+    .switch { width: 40px; height: 20px; }
+    .slider:before { height: 14px; width: 14px; }
+    .switch input:checked + .slider:before { transform: translateX(20px); }
     .report-grid { display: flex; }
-  }
-
-  @media (min-width: 1024px) {
-    #themeSwitchWrapper {
-      position: fixed;
-      top: 15px;
-      right: 15px;
-      z-index: 1200;
-    }
   }
 
     .temp-wrapper {
@@ -612,24 +621,33 @@ h1 {
     .color-danger  { background-color: var(--danger); color: white; }
 
 /* General info & network cards */
-.info-grid {
-  display: grid;
-  grid-template-columns: 1fr;
+.section-wrap {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
   gap: var(--gap-4);
 }
+
+.cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-lg);
+}
+.cards .info-card { justify-content: center; }
 .info-card { position:relative; display:flex; flex-direction:column; gap:var(--gap-2); }
 .info-card .card-head { display:flex; align-items:center; gap:var(--gap-2); }
-.info-card .card-title { display:flex; align-items:center; gap:var(--gap-2); font-weight:bold; }
+.info-card .card-title { display:flex; align-items:center; gap:var(--gap-2); font-weight:bold; flex:1; }
 .info-card .card-main { font-weight:bold; }
 .info-card .card-meta { font-size:var(--font-sm); color:var(--text-muted); display:flex; gap:var(--gap-2); flex-wrap:wrap; }
-.info-card .copy-icon { background:none; border:none; color:var(--text-muted); cursor:pointer; margin-left:auto; }
-.info-card .copy-icon:hover { color:var(--text); }
+.info-card .copy-btn { margin-left:auto; }
 .badge.success, .pill.success { background:var(--ok); color:#fff; }
 .badge.warning, .pill.warning { background:var(--warn); color:#000; }
 .badge.danger,  .pill.danger  { background:var(--crit); color:#fff; }
 
-@media (min-width: 768px) {
-  .info-grid { grid-template-columns: repeat(2, 1fr); }
+@media (min-width: 1024px) {
+  .cards { grid-template-columns: 1fr 1fr; }
+  .cards .card { height: 100%; }
 }
 
 .network-card { margin-top: var(--gap-4); }
@@ -661,16 +679,11 @@ h1 {
 .network-card .ip-label { font-size: var(--font-sm); color: var(--text-muted); }
 .network-card .ip-value { font-weight: 600; color: var(--ip-color); }
 .network-card .badge { margin-left: auto; flex-shrink: 0; }
-.network-card .ip-row .copy-icon {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  border-radius: 8px;
-  padding: 4px;
-  transition: background 0.2s, color 0.2s;
+.network-card .copy-btn {
   flex-shrink: 0;
 }
-.network-card .ip-row .copy-icon:hover {
+.network-card .copy-btn:hover,
+.network-card .copy-btn:focus-visible {
   background: var(--ip-color);
   color: var(--bg);
 }
@@ -1041,11 +1054,6 @@ h1 {
     }
     .service-item.expanded .service-details {
       display: block;
-    }
-    .copy-btn.small {
-      font-size: 0.8rem;
-      padding: 0.2rem;
-      margin-left: 0.3rem;
     }
     .service-skeleton {
       height: 2rem;


### PR DESCRIPTION
## Summary
- Refactor top bar using CSS Grid with centered branding and hostname
- Group date and uptime cards in responsive `.cards` grid and unify copy buttons
- Add shared `.copy-btn` styles and align network card with common section wrapper

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c706ecbec832db0921677c3ea396a