### PR TITLE
style: improve spacing and network header

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -518,6 +518,7 @@ h1 {
       display: flex;
       align-items: center;
       gap: 0.5rem;
+      margin-right: var(--gap-2);
     }
 
     .theme-icon {
@@ -650,7 +651,15 @@ h1 {
   .cards .card { height: 100%; }
 }
 
-.network-card { margin-top: var(--gap-4); }
+.network-card {
+  margin-top: var(--gap-5);
+}
+.network-card .card-title {
+  color: var(--subheading);
+}
+.network-card .card-title i {
+  color: var(--subheading);
+}
 .network-card .ip-row {
   --ip-color: var(--primary);
   display: flex;
@@ -1263,7 +1272,7 @@ h1 {
 
   main {
     max-width: 900px;
-    margin: auto;
+    margin: var(--gap-5) auto 0;
   }
 
   @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- add margin to theme switch so toggle remains visible
- increase spacing around top cards and network address card
- tint network addressing header in green

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c729d66e8832d891b12ec87daf9c2