### PR TITLE
Fix theme switch overlap and adjust network section

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -89,10 +89,8 @@
         </div>
       </div>
 
+      <h2 id="networkTitle"><i class="fa-solid fa-network-wired heading-icon"></i>Adressage réseau</h2>
       <div class="info-card card network-card" id="networkCard" aria-labelledby="networkTitle">
-    <div class="card-head">
-      <div class="card-title card__title" id="networkTitle"><i class="fa-solid fa-network-wired"></i><span>Adressage réseau</span></div>
-    </div>
     <div class="card-body">
         <div class="ip-row ip-local">
           <i class="fa-solid fa-computer ip-icon" aria-hidden="true"></i>

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -462,6 +462,7 @@ h1 {
       align-items: center;
       background: var(--block-bg);
       padding: 0.5rem 1rem;
+      padding-right: calc(1rem + var(--gap-2));
       z-index: 1100;
     }
 
@@ -518,7 +519,6 @@ h1 {
       display: flex;
       align-items: center;
       gap: 0.5rem;
-      margin-right: var(--gap-2);
     }
 
     .theme-icon {
@@ -569,6 +569,7 @@ h1 {
   @media screen and (max-width: 600px) {
     .top-bar {
       padding: 10px;
+      padding-right: calc(10px + var(--gap-2));
     }
     #themeSwitchWrapper { gap: 0.5rem; }
     .switch { width: 40px; height: 20px; }


### PR DESCRIPTION
## Summary
- prevent theme toggle from being hidden by the scrollbar
- move "Adressage réseau" heading outside its card for consistency

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c74277f3c832da4be885bd3519ef3