### PR TITLE
Fix theme switch visibility in header

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -457,6 +457,7 @@ h1 {
       top: 0;
       left: 0;
       width: 100%;
+      box-sizing: border-box;
       display: grid;
       grid-template-columns: auto 1fr auto;
       align-items: center;


### PR DESCRIPTION
## Summary
- ensure header width includes padding to prevent theme switch overflow

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c7850bb04832db6458aa32cf01e0a