### PR TITLE
Réduction de l'espacement du bloc réseau

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -654,7 +654,7 @@ h1 {
 }
 
 .network-card {
-  margin-top: var(--gap-5);
+  margin-top: 0;
 }
 .network-card .card-title {
   color: var(--subheading);


### PR DESCRIPTION
## Summary
- Aligne l'espacement entre le titre "Adressage réseau" et le bloc d'adresses IP en supprimant la marge supérieure dédiée.

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c796dcdfc832d96699e806f15bdfb