### PR TITLE
Affiche la date de génération et l'uptime dans le bandeau

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -23,6 +23,18 @@
         <span class="brand-title">Audit Serveur DW</span>
       </div>
       <p id="hostname" class="brand-host">-</p>
+      <div class="brand-meta">
+        <div class="meta-item">
+          <span class="meta-label">Généré</span>
+          <span id="generatedValue">--</span>
+          <span id="tzBadge" class="badge"></span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Uptime</span>
+          <span id="uptimeValue">--</span>
+          <span id="uptimeSince"></span>
+        </div>
+      </div>
     </div>
     <div id="themeSwitchWrapper">
       <i id="themeIcon" class="fas fa-moon theme-icon"></i>
@@ -68,28 +80,8 @@
   <div id="menuOverlay"></div>
 
   <main>
-    <section class="section-wrap">
-      <div class="cards">
-        <div class="info-card card" id="generatedCard" aria-labelledby="generatedTitle">
-          <div class="card-head">
-            <div class="card-title card__title" id="generatedTitle"><i class="fa-solid fa-calendar-day"></i><span>Date de génération</span></div>
-            <button id="copyGenerated" class="copy-btn" title="Copier la date" aria-label="Copier la date"><i class="fa-regular fa-copy"></i></button>
-          </div>
-          <div id="generatedValue" class="card-main">--</div>
-          <div class="card-meta card__meta"><span id="tzBadge" class="badge"></span></div>
-        </div>
-        <div class="info-card card" id="uptimeCard" aria-labelledby="uptimeTitle">
-          <div class="card-head">
-            <div class="card-title card__title" id="uptimeTitle"><i class="fa-solid fa-clock"></i><span>Temps de fonctionnement</span></div>
-            <span id="uptimeBadge" class="badge"></span>
-            <button id="copyUptime" class="copy-btn" title="Copier la durée" aria-label="Copier la durée"><i class="fa-regular fa-copy"></i></button>
-          </div>
-          <div id="uptimeValue" class="card-main">--</div>
-          <div id="uptimeSince" class="card-meta card__meta"></div>
-        </div>
-      </div>
-
-      <h2 id="networkTitle"><i class="fa-solid fa-network-wired heading-icon"></i>Adressage réseau</h2>
+      <section class="section-wrap">
+        <h2 id="networkTitle"><i class="fa-solid fa-network-wired heading-icon"></i>Adressage réseau</h2>
       <div class="info-card card network-card" id="networkCard" aria-labelledby="networkTitle">
     <div class="card-body">
         <div class="ip-row ip-local">

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1255,16 +1255,9 @@ function renderText(json) {
   const tz = json.timezone || json.tz;
   const tzBadge = document.getElementById('tzBadge');
   if (tz) { tzBadge.textContent = tz; tzBadge.style.display='inline-block'; } else { tzBadge.style.display='none'; }
-  setupCopy('copyGenerated', () => genEl.textContent);
-
   const upInfo = parseUptime(json.uptime);
   const upEl = document.getElementById('uptimeValue');
   upEl.textContent = upInfo.text;
-  setupCopy('copyUptime', () => upEl.textContent);
-  const upBadge = document.getElementById('uptimeBadge');
-  if (upBadge) {
-    upBadge.style.display = 'none';
-  }
   const bootTs = json.boot_ts || json.boot_time || null;
   const sinceEl = document.getElementById('uptimeSince');
   if (bootTs) {

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -491,6 +491,24 @@ h1 {
       opacity: 0.7;
     }
 
+    .brand-meta {
+      display: flex;
+      gap: var(--gap-3);
+      justify-content: center;
+      flex-wrap: wrap;
+      font-size: var(--font-sm);
+    }
+
+    .brand-meta .meta-item {
+      display: flex;
+      gap: var(--gap-1);
+      align-items: center;
+    }
+
+    .brand-meta .meta-label {
+      font-weight: 600;
+    }
+
     .menu-toggle {
       background: none;
       border: none;


### PR DESCRIPTION
## Summary
- Move generation date and uptime info from cards to the header
- Style new header metadata with smaller fonts
- Adjust script to populate new header fields

## Testing
- `./tests/run.sh` *(fails: mpstat, bc, ss missing; test script reports generated JSON)*

------
https://chatgpt.com/codex/tasks/task_e_689c7d15218c832d900363dff38a9bae