### PR TITLE
Fix update badge not showing for new reports

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -74,10 +74,10 @@
       </div>
 
       <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>
-      <span id="updateBadge" class="update-badge">Mis à jour</span>
     </div>
   </aside>
   <div id="menuOverlay"></div>
+  <span id="updateBadge" class="update-badge">Mis à jour</span>
 
   <main>
       <section class="section-wrap">


### PR DESCRIPTION
## Summary
- ensure "Mis à jour" badge displays by moving it outside the sliding sidebar so its fixed position is relative to the viewport

## Testing
- `./tests/run.sh` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_689c8a2ba7b0832db05ffcd11202afa9