### PR TITLE
Supprimer le cadre du menu Rapports

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -49,7 +49,6 @@
     <div id="reportCard" class="report-card card">
       <div class="card-header">
         <h2>Rapports</h2>
-        <p class="subtitle">Choisissez un moment</p>
       </div>
 
       <div class="report-grid">

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -203,12 +203,25 @@ h1 {
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.sidebar .card {
+  border: none;
+  box-shadow: none;
+}
+
+.sidebar .card:hover {
+  box-shadow: none;
+}
+
 .card:hover { box-shadow: 0 8px 24px rgba(0,0,0,0.2); transform: translateY(-2px); }
 
 .card--compact { padding: var(--gap-3); }
 .card__title { display:flex; align-items:center; gap:var(--gap-2); font-weight:600; }
 .card__title i { width:1.25rem; }
 .card__meta { font-size: var(--font-sm); color: var(--text-muted); margin-top: var(--gap-2); }
+
+.card-header {
+  margin-bottom: 1.5rem;
+}
 
 .report-card {
   position: relative;
@@ -379,9 +392,9 @@ h1 {
       font-size: 0.8rem;
     }
 
-    input:focus,
-    select:focus,
-    button:focus {
+    input:focus-visible,
+    select:focus-visible,
+    button:focus-visible {
       outline: 2px solid var(--heading);
       outline-offset: 2px;
     }


### PR DESCRIPTION
## Summary
- supprime le sous-texte « Choisissez un moment » du menu Rapports
- retire bordure et ombre portées sur le panneau latéral
- applique :focus-visible pour les styles de focus des éléments interactifs

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c9153728c832dbc271c98ad86e479