### PR TITLE
docs: document nginx deployment and update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Audit Server
 
-This project provides a lightweight way to collect and view system audit reports. A Bash script
-gathers metrics such as CPU usage, memory consumption, open ports and running services, then
-writes the results to JSON files. A small web frontend served by Nginx lets you browse these
-reports over time.
+This project provides a lightweight way to collect and view system audit reports. A Bash script gathers
+metrics such as CPU usage, memory consumption, open ports, running services, and Docker container stats,
+then writes the results to JSON files. Static files under `audits` display the reports through a simple web
+interface that can be served by Nginx.
 
 ## 🚀 Installation
 
@@ -21,72 +21,41 @@ reports over time.
    sudo apt-get install -y bc jq curl lm-sensors sysstat
    ```
 
-   You will also need [Node.js](https://nodejs.org/) if you plan to run the bundled server.
-
 3. ▶️ Generate your first audit
 
    ```bash
    ./generate-audit-json.sh
    ```
 
-## 🛠️ Requirements
-
-The `generate-audit-json.sh` script relies on a few common utilities:
-
-- ⚙️ `mpstat` and `bc` for CPU statistics
-- 📦 `jq` for JSON formatting
-- 🌡️ `sensors` for temperature readings (optional)
-- 🌐 `curl` to retrieve the public IP address
-
-Make sure these commands are available on the machine where you run the script.
-
-## 🧾 Generating an audit
-
-The script stores reports under `/home/damswallace/docker/audits-nginx/audits` by default. You can
-override the location by setting the `BASE_DIR` environment variable before running:
+The script writes reports to `/home/damswallace/docker/audits-nginx/audits/archives` by default. Override the
+location by setting the `BASE_DIR` environment variable:
 
 ```bash
-./generate-audit-json.sh
+BASE_DIR=./audits ./generate-audit-json.sh
 ```
-
-Each execution creates an `audit_YYYY-MM-DD_HH-MM.json` file inside `archives/` and updates
-`index.json` with the list of available reports. You can schedule the script via cron to capture
-snapshots at regular intervals.
-
-## 📂 Managing reports
-
-Run the lightweight Node server and use the web interface to browse existing audits:
-
-```bash
-node server.js
-```
-
-The dashboard lists reports from `archives/index.json` for easy review.
 
 ## 🌐 Serving the reports
 
-`server.js` serves the `audits` directory and provides the `/api/reports` endpoint used by the UI.
-It also exposes a `/healthz` path that returns `{ "ok": true }`, which is convenient for Docker
-health checks or reverse proxies such as Traefik. When containerized, expose port `8080` and point
-Traefik or any other proxy at that port. Start it with the command above and open
-`http://localhost:8080/` in a browser. The included `docker-compose.yaml` can still be used if you
-prefer an Nginx setup.
+Use the provided `docker-compose.yaml` and `nginx.conf` to serve the `audits` directory through Nginx and expose
+it behind Traefik. Adjust volume paths or labels as needed for your environment. Run:
+
+```bash
+docker compose up -d
+```
 
 ## 🗂️ Directory structure
 
 ```
-├── audits
-│   ├── index.html         # Web interface
-│   ├── scripts/viewer.js  # Frontend logic
-│   └── favicon.ico
-├── generate-audit-json.sh # Bash script to create audit_*.json files
-├── docker-compose.yaml    # Nginx setup for serving the reports
-└── nginx.conf             # Basic Nginx configuration
+├── audits               # Web interface and generated reports
+├── generate-audit-json.sh
+├── docker-compose.yaml
+└── nginx.conf
 ```
 
 ## 📚 Documentation
 
-Additional usage instructions are available in the [docs](docs/USAGE.md) directory.
+Additional usage instructions are available in the [docs](docs/USAGE.md) directory. Deployment options are
+covered in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 ## 🧪 Testing
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# 🚀 Deployment Guide
+
+This guide explains how to serve audit reports through Nginx running in Docker with Traefik.
+
+1. Generate audits (or schedule the script):
+
+   ```bash
+   ./generate-audit-json.sh
+   ```
+
+   Reports are stored under `/home/damswallace/docker/audits-nginx/audits/archives` by default. Use `BASE_DIR` to
+   change the location.
+
+2. Start the container:
+
+   ```bash
+   docker compose up -d
+   ```
+
+The `docker-compose.yaml` mounts the audit directory and `nginx.conf`, exposes port 80 on the `br-dams` network
+and sets Traefik labels for routing `audit.damswallace.fr`. Adjust paths, network settings or labels to fit your
+environment.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,35 +18,27 @@ This document provides extra details on how to use the audit script and serve th
    sudo apt-get install -y bc jq curl lm-sensors sysstat
    ```
 
-   Node.js is required to run `server.js`.
-
 ## 📊 Generating reports
 
-The `generate-audit-json.sh` script collects system information and writes it as JSON files. By
-default, reports are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override
-this location by setting the `BASE_DIR` environment variable:
+The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports
+are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override this location by setting the
+`BASE_DIR` environment variable:
 
 ```bash
-BASE_DIR=/tmp/audits ./generate-audit-json.sh
+BASE_DIR=./audits ./generate-audit-json.sh
 ```
 
-Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of
-available reports.
+Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of available
+reports.
 
-## 📂 Managing reports
+## 📂 Serving reports
 
-Start the Node server to browse audits from the web interface:
+Use the provided Docker and Nginx setup to serve the `audits` directory. Adjust paths or Traefik labels in
+`docker-compose.yaml` to match your environment:
 
 ```bash
-node server.js
+docker compose up -d
 ```
-
-The dashboard lists existing reports from `archives/index.json`.
-
-## 🌐 Serving the reports
-
-`server.js` serves the static files under `audits` and exposes the `/api/reports` endpoint. After
-starting it, open the reported address in a browser to view the dashboard.
 
 ## 🧪 Running tests
 

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -82,10 +82,10 @@ DOCKER_CONTAINERS="[]"
 if command -v docker >/dev/null 2>&1; then
   declare -A CPU MEM_PCT MEM_USED MEM_LIMIT
   while IFS= read -r line; do
-    name=$(echo "$line" | sed -n 's/.*"Name":"\([^"]*\)".*/\1/p')
-    cpu=$(echo "$line" | sed -n 's/.*"CPUPerc":"\([^"]*\)".*/\1/p' | tr -d '% ')
-    memp=$(echo "$line" | sed -n 's/.*"MemPerc":"\([^"]*\)".*/\1/p' | tr -d '% ')
-    usage=$(echo "$line" | sed -n 's/.*"MemUsage":"\([^"]*\)".*/\1/p')
+    name=$(echo "$line" | sed -n 's/.*"Name":"\([^\"]*\)".*/\1/p')
+    cpu=$(echo "$line" | sed -n 's/.*"CPUPerc":"\([^\"]*\)".*/\1/p' | tr -d '% ')
+    memp=$(echo "$line" | sed -n 's/.*"MemPerc":"\([^\"]*\)".*/\1/p' | tr -d '% ')
+    usage=$(echo "$line" | sed -n 's/.*"MemUsage":"\([^\"]*\)".*/\1/p')
     used=$(echo "$usage" | awk -F'/' '{gsub(/^[ \t]+|[ \t]+$/, "", $1); print $1}')
     limit=$(echo "$usage" | awk -F'/' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}')
     used_bytes=$(to_bytes "$used")
@@ -99,9 +99,9 @@ if command -v docker >/dev/null 2>&1; then
   DOCKER_PS_OUTPUT=$(docker ps -a --format '{{json .}}' 2>/dev/null || true)
   if [[ -n "$DOCKER_PS_OUTPUT" ]]; then
     while IFS= read -r line; do
-      name=$(echo "$line" | sed -n 's/.*"Names":"\([^"]*\)".*/\1/p')
-      status=$(echo "$line" | sed -n 's/.*"Status":"\([^"]*\)".*/\1/p')
-      running_for=$(echo "$line" | sed -n 's/.*"RunningFor":"\([^"]*\)".*/\1/p')
+      name=$(echo "$line" | sed -n 's/.*"Names":"\([^\"]*\)".*/\1/p')
+      status=$(echo "$line" | sed -n 's/.*"Status":"\([^\"]*\)".*/\1/p')
+      running_for=$(echo "$line" | sed -n 's/.*"RunningFor":"\([^\"]*\)".*/\1/p')
       state=$(echo "$status" | awk '{print tolower($1)}')
       [[ "$state" == "up" ]] && state="running"
       health=$(echo "$status" | sed -n 's/.*(\([^)]*\)).*/\1/p')

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,19 @@
+events {}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        root /usr/share/nginx/html;
+
+        location / {
+            index index.html;
+        }
+
+        # Pas besoin de location pour .js/.css si mime.types est inclus
+    }
+}


### PR DESCRIPTION
## Summary
- remove Node server and document Nginx-based deployment with Traefik labels
- point audit generator to host audit directory by default and describe BASE_DIR override
- update usage and deployment docs for new workflow

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689c92c2b250832d9eeee3436fde3983