### PR TITLE
feat: add trends dashboard

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -74,6 +74,7 @@
 
       <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>
     </div>
+    <a id="linkTrends" class="btn" href="trends.html"><i class="fa-solid fa-chart-line"></i> Tendances</a>
   </aside>
   <div id="menuOverlay"></div>
   <span id="updateBadge" class="update-badge">Un nouveau rapport est disponible, il a été chargé automatiquement</span>

--- a/audits/scripts/trends.js
+++ b/audits/scripts/trends.js
@@ -1,0 +1,130 @@
+async function fetchJSON(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Échec du chargement de ${url}`);
+  return res.json();
+}
+
+function labelFromFile(fn) {
+  const m = fn.match(/audit_(\d{4}-\d{2}-\d{2})_(\d{2}-\d{2})/);
+  return m ? `${m[1]} ${m[2].replace('-', ':')}` : fn;
+}
+
+function parseSizeToBytes(val) {
+  if (val == null) return 0;
+  const m = String(val).trim().replace(/,/g, '.').match(/^(\d+(?:\.\d+)?)(?:\s*(B|[KMGT](?:iB?|i|B)?))?$/i);
+  if (!m) return 0;
+  const num = parseFloat(m[1]);
+  const unit = (m[2] || 'B').toUpperCase();
+  const map = {
+    B: 1,
+    K: 1024, KB: 1024, KI: 1024, KIB: 1024,
+    M: 1024 ** 2, MB: 1024 ** 2, MI: 1024 ** 2, MIB: 1024 ** 2,
+    G: 1024 ** 3, GB: 1024 ** 3, GI: 1024 ** 3, GIB: 1024 ** 3,
+    T: 1024 ** 4, TB: 1024 ** 4, TI: 1024 ** 4, TIB: 1024 ** 4,
+  };
+  return num * (map[unit] || 1);
+}
+
+function setupMenu() {
+  const sidebar = document.getElementById('sidebar');
+  const overlay = document.getElementById('menuOverlay');
+  const toggle = document.getElementById('menuToggle');
+  if (!sidebar || !overlay || !toggle) return;
+  const icon = toggle.querySelector('i');
+  const closeMenu = () => {
+    sidebar.classList.remove('open');
+    overlay.classList.remove('open');
+    toggle.classList.remove('open');
+    icon.classList.remove('fa-xmark');
+    icon.classList.add('fa-bars');
+  };
+  toggle.addEventListener('click', () => {
+    const isOpen = sidebar.classList.toggle('open');
+    overlay.classList.toggle('open', isOpen);
+    toggle.classList.toggle('open', isOpen);
+    icon.classList.toggle('fa-bars', !isOpen);
+    icon.classList.toggle('fa-xmark', isOpen);
+  });
+  overlay.addEventListener('click', closeMenu);
+}
+
+async function loadTrends() {
+  const index = await fetchJSON('archives/index.json');
+  index.sort();
+  const labels = [];
+  const load1 = [], load5 = [], load15 = [], mem = [], disk = [];
+
+  for (const file of index) {
+    const data = await fetchJSON(`archives/${file}`);
+    labels.push(labelFromFile(file));
+
+    if (data.load_average) {
+      const parts = String(data.load_average).split(',').map(v => parseFloat(v));
+      load1.push(parts[0] || 0);
+      load5.push(parts[1] || 0);
+      load15.push(parts[2] || 0);
+    } else {
+      load1.push(0); load5.push(0); load15.push(0);
+    }
+
+    if (data.memory && data.memory.ram) {
+      const used = parseSizeToBytes(data.memory.ram.used);
+      const total = parseSizeToBytes(data.memory.ram.total);
+      mem.push(total ? (used / total) * 100 : 0);
+    } else {
+      mem.push(0);
+    }
+
+    if (Array.isArray(data.disks) && data.disks.length) {
+      let tot = 0, used = 0;
+      for (const d of data.disks) {
+        tot += parseSizeToBytes(d.size);
+        used += parseSizeToBytes(d.used);
+      }
+      disk.push(tot ? (used / tot) * 100 : 0);
+    } else {
+      disk.push(0);
+    }
+  }
+
+  new Chart(document.getElementById('loadChart'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: '1 min', data: load1, borderColor: 'var(--accent)', fill: false },
+        { label: '5 min', data: load5, borderColor: 'var(--primary)', fill: false },
+        { label: '15 min', data: load15, borderColor: 'var(--warn)', fill: false },
+      ],
+    },
+    options: { responsive: true, scales: { y: { beginAtZero: true } } },
+  });
+
+  new Chart(document.getElementById('memChart'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'RAM % utilisée', data: mem, borderColor: 'var(--primary)', fill: false },
+      ],
+    },
+    options: { responsive: true, scales: { y: { beginAtZero: true, max: 100 } } },
+  });
+
+  new Chart(document.getElementById('diskChart'), {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Disque % utilisé', data: disk, borderColor: 'var(--crit)', fill: false },
+      ],
+    },
+    options: { responsive: true, scales: { y: { beginAtZero: true, max: 100 } } },
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupMenu();
+  loadTrends().catch(err => console.error(err));
+});
+

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -192,7 +192,7 @@ h1 {
       color: var(--bg);
     }
 
- .btn.primary:hover { filter: brightness(1.1); }
+.btn.primary:hover { filter: brightness(1.1); }
 
 .card {
   background: var(--bg-card);
@@ -201,6 +201,11 @@ h1 {
   box-shadow: var(--shadow);
   padding: var(--gap-4);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.chart-card canvas {
+  width: 100%;
+  height: 300px;
 }
 
 .sidebar .card {

--- a/audits/trends.html
+++ b/audits/trends.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Audit Serveur DW - Tendances</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Font Awesome -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="scripts/trends.js" defer></script>
+</head>
+<body data-theme="dark">
+  <header id="topBar" class="top-bar">
+    <button id="menuToggle" class="menu-toggle"><i class="fa-solid fa-bars"></i></button>
+    <div class="top-brand">
+      <div class="brand-line">
+        <i class="fa-solid fa-brain" aria-hidden="true"></i>
+        <span class="brand-title">Audit Serveur DW</span>
+      </div>
+      <p id="hostname" class="brand-host">-</p>
+      <div class="brand-meta">
+        <div class="meta-item">
+          <span class="meta-label">Généré</span>
+          <span id="generatedValue">--</span>
+          <span id="tzBadge" class="badge"></span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Uptime</span>
+          <span id="uptimeValue">--</span>
+          <span id="uptimeSince"></span>
+        </div>
+      </div>
+    </div>
+    <div id="themeSwitchWrapper">
+      <i id="themeIcon" class="fas fa-moon theme-icon"></i>
+      <label class="switch">
+        <input type="checkbox" id="themeToggle">
+        <span class="slider"></span>
+      </label>
+    </div>
+  </header>
+
+  <aside id="sidebar" class="sidebar">
+    <div id="reportCard" class="report-card card">
+      <div class="card-header">
+        <h2>Rapports</h2>
+      </div>
+
+      <div class="report-grid">
+        <button id="btnLatest" class="btn primary">
+          <span><i class="fa-solid fa-bolt"></i></span>
+          <span class="label">Voir le dernier rapport</span>
+          <small id="latestInfo" class="subinfo"></small>
+        </button>
+
+        <div class="day-control" role="group" aria-label="Choisir un jour">
+          <button id="dayToday" class="seg">Aujourd'hui</button>
+          <button id="dayYesterday" class="seg">Hier</button>
+          <button id="dayCalendar" class="seg" aria-label="Choisir une date" title="Choisir une date"><i class="fa-solid fa-calendar"></i></button>
+          <input type="date" id="datePicker" class="sr-only" />
+        </div>
+
+        <div id="selectorStatus" aria-live="polite"></div>
+
+        <div class="timeline-wrapper">
+          <div id="timeTimeline" class="timeline" aria-live="polite"></div>
+        </div>
+      </div>
+
+      <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>
+    </div>
+    <a id="linkTrends" class="btn" href="trends.html"><i class="fa-solid fa-chart-line"></i> Tendances</a>
+  </aside>
+  <div id="menuOverlay"></div>
+
+  <main>
+    <h2><i class="fa-solid fa-chart-line heading-icon"></i>Tendances des métriques</h2>
+    <div class="card chart-card">
+      <h3>Charge moyenne</h3>
+      <canvas id="loadChart"></canvas>
+    </div>
+    <div class="card chart-card">
+      <h3>Mémoire utilisée (%)</h3>
+      <canvas id="memChart"></canvas>
+    </div>
+    <div class="card chart-card">
+      <h3>Disque utilisé (%)</h3>
+      <canvas id="diskChart"></canvas>
+    </div>
+  </main>
+
+  <script>
+    const themeSwitch = document.getElementById("themeToggle");
+    const themeIcon = document.getElementById("themeIcon");
+    function applyTheme(t){
+      document.body.setAttribute("data-theme", t);
+      themeSwitch.checked = t === "light";
+      if (themeIcon) themeIcon.className = t === "light" ? "fas fa-sun theme-icon" : "fas fa-moon theme-icon";
+    }
+    themeSwitch.addEventListener("change", () => {
+      const next = themeSwitch.checked ? "light" : "dark";
+      localStorage.setItem("theme", next);
+      applyTheme(next);
+    });
+    applyTheme(localStorage.getItem("theme") || "dark");
+  </script>
+</body>
+</html>
+

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -40,6 +40,12 @@ Use the provided Docker and Nginx setup to serve the `audits` directory. Adjust 
 docker compose up -d
 ```
 
+## 📈 Viewing trends
+
+The `audits/trends.html` page aggregates historical reports and displays charts for load averages, memory usage and
+disk consumption. Ensure the `archives` folder and `index.json` are served alongside this file so the browser can load
+past reports.
+
 ## 🧪 Running tests
 
 A minimal test script ensures the audit generator produces valid JSON output. Execute:


### PR DESCRIPTION
## Summary
- add "Tendances" link to sidebar
- add trends page with charts and theme/menu support
- aggregate historical metrics and style chart cards

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689da15e39a4832db5199a9d87cd65c0