### PR TITLE
Refactor memory usage cards

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -875,6 +875,7 @@ h1 {
     .mem .badge.ok { background: var(--ok); color: #fff; }
     .mem .badge.warn { background: var(--warn); color: #000; }
     .mem .badge.crit { background: var(--crit); color: #fff; }
+    .mem .no-swap { text-align: center; padding: var(--gap-2) 0; color: var(--muted); }
     .mem .seg[data-tip]:hover::after,
     .mem .badge[data-tip]:hover::after {
       content: attr(data-tip);


### PR DESCRIPTION
## Summary
- compute RAM usage from available memory and normalize size formatting
- harmonize RAM & swap cards with consistent badges and no-swap message
- add basic console tests for memory utilities

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689da798f5c4832db6018aad1bb94c7c