### PR TITLE
Refine CPU card header and formatting

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -901,12 +901,12 @@ function summarizeCpu(usageArr=[], tempArr=[], tjmax=100){
 
 function formatPercentFR(n){
   if(n==null || isNaN(n)) return 'N/A';
-  return `${Math.round(n).toLocaleString('fr-FR')} %`;
+  return `${Math.round(n).toLocaleString('fr-FR')} %`;
 }
 
 function formatTempFR(c){
   if(c==null || isNaN(c)) return 'N/A';
-  return `${Number(c).toLocaleString('fr-FR',{minimumFractionDigits:1, maximumFractionDigits:1})} °C`;
+  return `${Number(c).toLocaleString('fr-FR',{minimumFractionDigits:1, maximumFractionDigits:1})} °C`;
 }
 
 function classForSeverity(sev){
@@ -934,13 +934,12 @@ function renderCpu(cpu){
   card.className = 'card cpu';
   card.innerHTML = `
     <div class="card-head">
-      <div class="title"><i class="fa-solid fa-gear" aria-hidden="true"></i><span>CPU</span></div>
-      <div class="subtitle">${model} — ${cpu.cores ?? 'N/A'} cœurs</div>
-    </div>
-    <div class="summary">
-      <div class="badge"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i><span>${formatPercentFR(summary.avgUsage)}</span></div>
-      <div class="badge"><i class="fa-solid fa-temperature-three-quarters" aria-hidden="true"></i><span>${formatTempFR(summary.avgTemp)}</span></div>
-      <div class="badge"><i class="fa-solid fa-arrow-up" aria-hidden="true"></i><span>${summary.max.core!=null?`Core ${summary.max.core} — ${formatPercentFR(summary.max.usage)} / ${formatTempFR(summary.max.temp)}`:'N/A'}</span></div>
+      <div class="summary">
+        <div class="badge"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i><span>${formatPercentFR(summary.avgUsage)}</span></div>
+        <div class="badge"><i class="fa-solid fa-temperature-three-quarters" aria-hidden="true"></i><span>${formatTempFR(summary.avgTemp)}</span></div>
+        <div class="badge"><i class="fa-solid fa-arrow-up" aria-hidden="true"></i><span>${summary.max.core!=null?`Core ${summary.max.core} — ${formatPercentFR(summary.max.usage)} / ${formatTempFR(summary.max.temp)}`:'N/A'}</span></div>
+      </div>
+      <div class="model">${model} <em class="cores">— ${cpu.cores ?? 'N/A'} cœurs</em></div>
     </div>
     <div class="core-list"></div>`;
 
@@ -1023,7 +1022,7 @@ function renderCpu(cpu){
 }
 
 console.assert(percentOfTjMax(73,100) === 73, 'percentOfTjMax');
-console.assert(formatTempFR(73) === '73,0 °C', 'formatTempFR', formatTempFR(73));
+console.assert(formatTempFR(73) === '73,0 °C', 'formatTempFR', formatTempFR(73));
 const __cpuTest = summarizeCpu(
   [{core:0,usage:6},{core:1,usage:12},{core:2,usage:17},{core:3,usage:23}],
   [{core:0,temp:73},{core:1,temp:73},{core:2,temp:73},{core:3,temp:73}],

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1231,11 +1231,13 @@ h1 {
     .chip.free { background: #4caf50; color: #fff; }
     .disk-card { margin-bottom: 0.5rem; }
     .cpu .card-head { display:flex; align-items:center; justify-content:space-between; gap:var(--gap-2); flex-wrap:wrap; }
-    .cpu .title { display:flex; align-items:center; gap:var(--gap-2); font-weight:bold; }
-    .cpu .subtitle { font-size:var(--font-sm); color:var(--text-muted); }
-    .cpu .summary { display:flex; gap:var(--gap-2); flex-wrap:wrap; margin-top:var(--gap-2); }
+    .cpu .summary { display:flex; gap:var(--gap-2); flex-wrap:wrap; }
+    .cpu .summary .badge { white-space:nowrap; }
+    .cpu .model { font-size:var(--font-sm); color:var(--text-muted); }
+    .cpu .cores { font-style:italic; }
     .cpu .core-list { margin-top:var(--gap-3); display:flex; flex-direction:column; gap:var(--gap-2); }
     .cpu .core-bars { display:flex; flex-direction:column; gap:4px; flex:1 0 160px; }
+    .cpu .bar-temp .fill { opacity:0.8; }
     .cpu .crit-badge { margin-left:var(--gap-2); }
 
     @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Remove redundant CPU title in CPU card and align summary badges with muted model/cores info
- Use narrow non‑breaking spaces in percent and temperature formatting
- Differentiate temperature bars with reduced opacity and prevent badge wrapping

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689daeaa1714832db53756b51cf06d39