### PR TITLE
Remove IP row borders in network card

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -741,10 +741,6 @@ h1 {
   align-items: center;
   gap: var(--gap-2);
   padding: var(--gap-2);
-  background: var(--bg-muted);
-  border-radius: var(--radius);
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-  border-left: 4px solid var(--ip-color);
   flex-wrap: wrap;
 }
 .network-card .ip-row + .ip-row { margin-top: var(--gap-2); }


### PR DESCRIPTION
## Summary
- remove background, border, and shadow from network card IP rows so local and public IPs display without frames

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689de0cbc64c832d92b84724e4124bf2