### PR TITLE
feat: enhance memory section

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1121,7 +1121,7 @@ function renderMemory(model){
     card.className = 'card ram';
     card.innerHTML = `
       <div class="card-head">
-        <div class="title">RAM <span class="badge total">${formatBytesFR(info.totalBytes)}</span></div>
+        <div class="title">RAM</div>
       </div>
       <div class="bar" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
       <div class="badge-row"></div>`;
@@ -1141,6 +1141,7 @@ function renderMemory(model){
     bar.appendChild(label);
 
     const items = [
+      {icon:'fa-database', label:'Total', val:info.totalBytes, cls:'total'},
       {icon:'fa-microchip', label:'Utilisée', val:info.usedAppsBytes, cls:pctClass(info.percent), tip:'Mémoire utilisée par les applications'},
       {icon:'fa-circle', label:'Libre', val:info.freeBytes, tip:'Mémoire libre'},
       {icon:'fa-layer-group', label:'Cache/buffers', val:info.cacheBytes, tip:'Mémoire cache et buffers'},
@@ -1166,7 +1167,7 @@ function renderMemory(model){
     card.className = 'card swap';
     card.innerHTML = `
       <div class="card-head">
-        <div class="title">Swap <span class="badge total">${formatBytesFR(info.totalBytes)}</span></div>
+        <div class="title">Swap</div>
       </div>
       <div class="bar" role="progressbar" aria-label="Utilisation Swap" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
       <div class="badge-row"></div>`;
@@ -1186,6 +1187,7 @@ function renderMemory(model){
     bar.appendChild(label);
 
     const items = [
+      {icon:'fa-database', label:'Total', val:info.totalBytes, cls:'total'},
       {icon:'fa-microchip', label:'Utilisée', val:info.usedBytes, cls:pctClass(info.percent ?? 0)},
       {icon:'fa-circle', label:'Libre', val:info.freeBytes}
     ];

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -833,6 +833,7 @@ h1 {
     .mem .bar {
       position: relative;
       display: flex;
+      width: 100%;
       height: 1.5rem;
       background: var(--bar-bg);
       border-radius: 4px;


### PR DESCRIPTION
## Summary
- align RAM and Swap cards with matching progress bars
- display total RAM and Swap figures alongside detailed memory stats
- ensure bars expand to full width for consistent layout

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689de67ab190832da6b08377f3186c04