### PR TITLE
fix: isolate memory bar styling

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1127,14 +1127,16 @@ function renderMemory(model){
       <div class="card-head">
         <div class="title">RAM</div>
       </div>
-      <div class="bar" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
+      <div class="bar mem-bar" role="progressbar" aria-label="Utilisation RAM" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
       <div class="badge-row"></div>`;
     const bar = card.querySelector('.bar');
     const badges = card.querySelector('.badge-row');
 
     const seg = document.createElement('div');
     seg.className = `seg seg-used ${pctClass(info.percent)}`;
-    seg.style.width = (info.percent ?? 0) + '%';
+    const pctRam = info.percent ?? 0;
+    const pctRamWidth = pctRam > 0 && pctRam < 1 ? 1 : pctRam;
+    seg.style.width = pctRamWidth + '%';
     const tip = `Utilisée : ${formatBytesFR(info.usedAppsBytes)} (${info.percent ?? 0} %)`;
     seg.title = tip;
     seg.setAttribute('aria-label', tip);
@@ -1178,14 +1180,16 @@ function renderMemory(model){
       <div class="card-head">
         <div class="title">Swap</div>
       </div>
-      <div class="bar" role="progressbar" aria-label="Utilisation Swap" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
+      <div class="bar mem-bar" role="progressbar" aria-label="Utilisation Swap" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${info.percent ?? 0}"></div>
       <div class="badge-row"></div>`;
     const bar = card.querySelector('.bar');
     const badges = card.querySelector('.badge-row');
 
     const seg = document.createElement('div');
     seg.className = `seg seg-used ${pctClass(info.percent ?? 0)}`;
-    seg.style.width = (info.percent ?? 0) + '%';
+    const pctSwap = info.percent ?? 0;
+    const pctSwapWidth = pctSwap > 0 && pctSwap < 1 ? 1 : pctSwap;
+    seg.style.width = pctSwapWidth + '%';
     const tip = `Utilisée : ${formatBytesFR(info.usedBytes)} (${info.percent ?? 0} %)`;
     seg.title = tip;
     seg.setAttribute('aria-label', tip);

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -830,15 +830,6 @@ h1 {
     .mem .percent.ok { color: var(--ok); }
     .mem .percent.warn { color: var(--warn); }
     .mem .percent.crit { color: var(--crit); }
-    .mem .bar {
-      position: relative;
-      display: flex;
-      width: 100%;
-      height: 1.5rem;
-      background: var(--bar-bg);
-      border-radius: 4px;
-      overflow: hidden;
-    }
     .mem .seg {
       position: relative;
       display: flex;
@@ -853,18 +844,6 @@ h1 {
     .mem .seg-cache { background: var(--chip-bg); }
     .mem .seg-free { background: var(--bar-bg); }
     .mem .seg .label.hidden { display: none; }
-    .mem .bar-label {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: var(--font-sm);
-      font-weight: 600;
-      color: var(--text);
-      text-shadow: 0 0 2px var(--bg);
-      pointer-events: none;
-    }
     .mem .bar-legend {
       display: flex;
       flex-wrap: wrap;
@@ -1180,7 +1159,7 @@ h1 {
     .proc-icon { width: 1.5rem; text-align: center; flex: 0 0 1.5rem; }
     .proc-name { font-weight: bold; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
     .proc-bars { display: flex; gap: 8px; flex: 1; }
-    .bar {
+    .bar:not(.mem-bar) {
       flex: 1;
       position: relative;
       display: flex;
@@ -1191,7 +1170,7 @@ h1 {
       overflow: hidden;
       background-color: var(--bar-bg, #333);
     }
-    .bar .fill {
+    .bar:not(.mem-bar) .fill {
       position: absolute;
       left: 0;
       top: 0;
@@ -1200,13 +1179,41 @@ h1 {
       border-radius: 6px;
       transition: width 250ms ease;
     }
-    .bar .value {
+    .bar:not(.mem-bar) .value {
       position: relative;
       z-index: 1;
       color: #fff;
       font-size: 0.75rem;
       font-weight: 600;
       white-space: nowrap;
+    }
+
+    /* Mémoire : barre dédiée, non impactée par .bar générique */
+    .mem .bar.mem-bar {
+      position: relative;
+      display: flex;
+      align-items: stretch;
+      width: 100%;
+      height: 1.5rem;
+      background: var(--bar-bg);
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .mem .seg {
+      height: 100%;
+      min-width: 2px;
+    }
+    .mem .bar-label {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--font-sm);
+      font-weight: 600;
+      color: var(--text);
+      text-shadow: 0 0 2px var(--bg);
+      pointer-events: none;
     }
     .fill.color-success { background: var(--success); }
     .fill.color-warning { background: var(--warning); color: #000; }


### PR DESCRIPTION
## Summary
- make RAM and Swap bars use a dedicated `mem-bar` class
- scope generic `.bar` styles away from memory bars and add specific memory bar styles
- ensure memory usage segments remain visible even for very small values

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e564895dc832dbcb96b197eb986f7