### PR TITLE
Improve disk donut interactions

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1247,10 +1247,10 @@ function renderDisks(disks){
     card.tabIndex = 0;
     const aria = `Disque ${disk.mountpoint} : ${pctDisplay}% utilisés, ${usedStr} utilisés, ${freeStr} libres, total ${totalStr}`;
     card.innerHTML = `
-      <svg class="disk-donut" viewBox="0 0 36 36" role="img" aria-label="${aria}">
-        <circle class="donut-bg" cx="18" cy="18" r="16"></circle>
-        <circle class="donut-ring ${colorClassDisk(pctRaw)}" cx="18" cy="18" r="16" stroke-dasharray="0 100"></circle>
-        <text x="18" y="18" class="donut-value">${pctDisplay}%</text>
+      <svg class="disk-donut" viewBox="0 0 40 40" role="img" aria-label="${aria}">
+        <circle class="donut-bg" cx="20" cy="20" r="16"></circle>
+        <circle class="donut-ring ${colorClassDisk(pctRaw)}" cx="20" cy="20" r="16" stroke-dasharray="0 100"></circle>
+        <text x="20" y="20" class="donut-value">${pctDisplay}%</text>
       </svg>
       <div class="disk-badges">
         <span class="badge">${disk.mountpoint}</span>
@@ -1263,24 +1263,22 @@ function renderDisks(disks){
       ring.setAttribute('stroke-dasharray', `${pctArc} 100`);
     });
     const tip = card.querySelector('.disk-tooltip');
-    function positionTip(){
-      const rect = card.getBoundingClientRect();
-      const tRect = tip.getBoundingClientRect();
-      let top = -tRect.height - 8;
-      if (rect.top + top < 0) top = rect.height + 8;
-      let left = (rect.width - tRect.width) / 2;
-      const overflowRight = rect.left + left + tRect.width - window.innerWidth;
-      if (overflowRight > 0) left -= overflowRight;
-      if (rect.left + left < 0) left = -rect.left + 4;
-      tip.style.top = top + 'px';
-      tip.style.left = left + 'px';
-    }
-    card.addEventListener('mouseenter', () => {
+    ring.addEventListener('mouseenter', () => {
       card.classList.add('show-tooltip');
-      positionTip();
     });
-    card.addEventListener('mouseleave', () => {
+    ring.addEventListener('mouseleave', () => {
       card.classList.remove('show-tooltip');
+    });
+    ring.addEventListener('mousemove', e => {
+      const rect = card.getBoundingClientRect();
+      let left = e.clientX - rect.left + 8;
+      let top = e.clientY - rect.top - tip.offsetHeight - 8;
+      const maxLeft = rect.width - tip.offsetWidth - 4;
+      if (left > maxLeft) left = maxLeft;
+      if (left < 4) left = 4;
+      if (top < 4) top = e.clientY - rect.top + 8;
+      tip.style.left = left + 'px';
+      tip.style.top = top + 'px';
     });
     card.addEventListener('click', () => {
       const txt = `mountpoint=${disk.mountpoint} • used=${usedStr} • free=${freeStr} • total=${totalStr} • ${pctDisplay}%`;

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1287,16 +1287,16 @@ h1 {
     .disk-grid { display:grid; gap:var(--gap-3); grid-template-columns:1fr; }
     @media (min-width:600px) { .disk-grid { grid-template-columns:repeat(2,1fr); } }
     .disk-card { background:var(--block-bg); border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.2); padding:var(--gap-3); text-align:center; position:relative; }
-    .disk-donut { width:100px; height:100px; margin:0 auto; display:block; }
+    .disk-donut { width:120px; height:120px; margin:0 auto; display:block; }
     .disk-donut .donut-bg { fill:none; stroke:var(--bar-bg); stroke-width:3; }
-    .disk-donut .donut-ring { fill:none; stroke-width:3; stroke-linecap:round; transform:rotate(-90deg); transform-origin:50% 50%; transition:stroke-dasharray .6s ease, stroke-width .2s ease; }
+    .disk-donut .donut-ring { fill:none; stroke-width:3; stroke-linecap:round; transform:rotate(-90deg); transform-origin:50% 50%; transition:stroke-dasharray .6s ease, stroke-width .2s ease; pointer-events:stroke; }
     .disk-donut .donut-ring.color-success { stroke:var(--success); }
     .disk-donut .donut-ring.color-warning { stroke:var(--warn); }
     .disk-donut .donut-ring.color-danger { stroke:var(--crit); }
-    .disk-card:hover .donut-ring { stroke-width:5; }
-    .donut-value { fill:var(--text); font-size:0.8rem; font-weight:700; text-anchor:middle; dominant-baseline:middle; }
+    .disk-donut .donut-ring:hover { stroke-width:5; }
+    .donut-value { fill:var(--text); font-size:0.7rem; font-weight:700; text-anchor:middle; dominant-baseline:middle; }
     .disk-badges { display:flex; justify-content:space-between; margin-top:var(--gap-2); }
-    .disk-tooltip { position:absolute; left:50%; background:var(--bg-card); color:var(--text); padding:4px 8px; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.2); font-size:var(--font-sm); white-space:nowrap; opacity:0; pointer-events:none; transform:translateX(-50%); transition:opacity .2s; z-index:20; }
+    .disk-tooltip { position:absolute; top:0; left:0; background:var(--bg-card); color:var(--text); padding:4px 8px; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.2); font-size:var(--font-sm); white-space:nowrap; opacity:0; pointer-events:none; transition:opacity .2s; z-index:20; }
     .disk-card.show-tooltip .disk-tooltip { opacity:1; }
     .cpu .card-head { display:flex; align-items:center; justify-content:space-between; gap:var(--gap-2); flex-wrap:wrap; }
     .cpu .summary { display:flex; gap:var(--gap-2); flex-wrap:wrap; }


### PR DESCRIPTION
## Summary
- enlarge disk donuts and reduce center percentage text
- show tooltip and ring highlight only when hovering used space
- make tooltip follow the cursor and prevent donut clipping

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e5c11e328832d99e97d9385c4790f