### PR TITLE
Improve load average layout and spacing

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -143,11 +143,6 @@
           </div>
       </div>
     </div>
-    <div class="load-legend">
-      <span class="badge success">Faible</span>
-      <span class="badge warning">Élevée</span>
-      <span class="badge danger">Critique</span>
-    </div>
   </div>
 
   <h2 id="cpuTitle"><i class="fa-solid fa-gear heading-icon"></i>CPU</h2>

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1015,13 +1015,6 @@ h1 {
 .kpi { width:200px; height:200px; border-radius:50%; display:grid; place-items:center; }
 @media (max-width:600px){ .kpi { width:150px; height:150px; } }
 
-    .load-legend {
-      margin-top: 0.75rem;
-      display: flex;
-      justify-content: center;
-      gap: 0.5rem;
-    }
-    .load-legend .badge { margin: 0; }
 
     .services-title-row {
       display: flex;
@@ -1315,7 +1308,9 @@ h1 {
 
     @media (min-width: 768px) {
       .load-container { flex-direction: row; align-items: center; }
-      .load-cards { flex: none; width: 200px; }
+      .gauge { width: 200px; height: 200px; }
+      .load-cards { flex: 1; flex-direction: row; }
+      .load-cards .mini-card { flex: 1; }
     }
 
     @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- remove redundant load legend under the gauge
- expand gauge and arrange load cards horizontally on wide screens for better space usage

## Testing
- `./tests/run.sh` *(fails: mpstat, bc, ss missing; audit JSON generated)*

------
https://chatgpt.com/codex/tasks/task_e_689e64fe18e0832dbbc15dc6f322c348