### PR TITLE
Refactor load average card for responsive layout

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -131,7 +131,7 @@
               <div class="bar" id="load5Bar"><span id="load5Fill" class="fill"></span></div>
               <span id="load5Val" class="mini-val">--</span>
             </div>
-            <div id="load5Trend" class="mini-trend">--</div>
+            <div id="load5Trend" class="mini-trend"><i class="fa-solid fa-minus"></i><span>--</span></div>
           </div>
           <div id="load15Card" class="mini-card" tabindex="0">
             <div class="mini-title"><span id="load15Dot" class="status-dot"></span>15 min</div>
@@ -139,7 +139,7 @@
               <div class="bar" id="load15Bar"><span id="load15Fill" class="fill"></span></div>
               <span id="load15Val" class="mini-val">--</span>
             </div>
-            <div id="load15Trend" class="mini-trend">--</div>
+            <div id="load15Trend" class="mini-trend"><i class="fa-solid fa-minus"></i><span>--</span></div>
           </div>
       </div>
     </div>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1327,7 +1327,7 @@ function renderMini(label, load, prevLoad, cores) {
     valEl.textContent = '—';
     fill.style.width = '0%';
     fill.className = 'fill';
-    trend.textContent = 'donnée manquante';
+    trend.innerHTML = '<i class="fa-solid fa-minus"></i><span>donnée manquante</span>';
     card.removeAttribute('title');
     card.removeAttribute('aria-label');
     bar.removeAttribute('aria-label');
@@ -1344,7 +1344,7 @@ function renderMini(label, load, prevLoad, cores) {
     });
     dot.style.background = status.color;
     const t = trendFrom(load, prevLoad);
-    trend.textContent = t.label;
+    trend.innerHTML = `<i class="fa-solid ${t.icon}"></i><span>${t.label}</span>`;
     const rawStr = load.toLocaleString('fr-FR', {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
@@ -1360,7 +1360,26 @@ function renderMini(label, load, prevLoad, cores) {
   }
 }
 
+let loadGaugeObserver;
+
+function setupLoadGauge() {
+  const gauge = document.getElementById('loadGauge');
+  if (!gauge || loadGaugeObserver) return;
+  const bg = gauge.querySelector('path.bg');
+  const path = document.getElementById('loadGaugePath');
+  const update = () => {
+    const size = gauge.offsetWidth;
+    const stroke = size * 0.12;
+    bg.style.strokeWidth = stroke + 'px';
+    path.style.strokeWidth = stroke + 'px';
+  };
+  loadGaugeObserver = new ResizeObserver(update);
+  loadGaugeObserver.observe(gauge);
+  update();
+}
+
 function renderLoadAverage(raw, cores) {
+  setupLoadGauge();
   const gauge = document.getElementById('loadGauge');
   const path = document.getElementById('loadGaugePath');
   const trendEl = document.getElementById('loadTrend');

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -959,58 +959,58 @@ h1 {
     .port-line .risk-dot { margin-left:0.3rem; }
     .port-line .copy-btn { margin-left:0.3rem; }
 
+    #loadCard { width:100%; min-height:clamp(260px,38vh,520px); }
+
     .load-container {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
+      display: grid;
+      width: 100%;
+      grid-template-columns: 1fr;
+      gap: var(--gap-4);
       align-items: center;
     }
 
-    .load-main {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-    }
+    .load-main { display:flex; flex-direction:column; align-items:center; }
 
     .gauge {
       position: relative;
-      width: 160px;
-      height: 160px;
-      margin: auto;
+      width: 100%;
+      max-width: 520px;
+      aspect-ratio: 1/1;
+      margin: 0 auto;
     }
-    .gauge svg { width: 100%; height: 100%; transform: rotate(-90deg); }
-    .gauge .bg { fill: none; stroke: #444; stroke-width: 3.5; }
-    .gauge .progress { fill: none; stroke: var(--load-color, var(--ok)); stroke-width: 3.5; stroke-linecap: round; transition: stroke 0.3s, stroke-dasharray 0.3s ease; }
-    .gauge-value { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-size: 2rem; font-weight: bold; display: flex; align-items: baseline; }
+    .gauge svg { width:100%; height:100%; transform:rotate(-90deg); }
+    .gauge .bg { fill:none; stroke:var(--bar-bg); stroke-width:3.5; }
+    .gauge .progress { fill:none; stroke:var(--load-color, var(--ok)); stroke-width:3.5; stroke-linecap:round; transition:stroke 0.3s, stroke-dasharray 0.3s ease; }
+    .gauge-value { position:absolute; top:50%; left:50%; transform:translate(-50%,-50%); font-size:clamp(28px,6.5vw,56px); font-weight:800; display:flex; align-items:baseline; }
     .gauge-label {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.25rem;
-      text-align: center;
-      margin-top: 0.5rem;
-      font-size: 1rem;
-      line-height: 1.3;
-      opacity: 0.8;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:0.25rem;
+      text-align:center;
+      margin-top:0.5rem;
+      font-size:1rem;
+      line-height:1.3;
+      opacity:0.8;
     }
-    .trend { font-size: 1rem; }
+    .trend { font-size:1rem; }
 
     .load-cards {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      width: 100%;
+      display:grid;
+      grid-auto-rows:1fr;
+      gap:var(--gap-4);
+      align-content:space-between;
+      width:100%;
     }
 
-    .mini-card { display:flex; flex-direction:column; gap:var(--gap-1); }
+    .mini-card { display:flex; flex-direction:column; gap:var(--gap-1); min-height:120px; }
     .mini-card.na { opacity:0.5; }
     .mini-title { font-size:var(--font-sm); display:flex; align-items:center; gap:0.4rem; }
     .status-dot { width:0.6rem; height:0.6rem; border-radius:50%; background:var(--ok); }
     .mini-bar-row { display:flex; align-items:center; gap:var(--gap-1); }
     .mini-bar-row .bar { flex:1; }
     .mini-val { font-weight:600; font-size:var(--font-sm); }
-    .mini-trend { font-size:var(--font-sm); opacity:0.8; }
+    .mini-trend { font-size:var(--font-sm); opacity:0.8; display:flex; align-items:center; gap:0.25rem; }
 
 .kpi { width:200px; height:200px; border-radius:50%; display:grid; place-items:center; }
 @media (max-width:600px){ .kpi { width:150px; height:150px; } }
@@ -1306,16 +1306,17 @@ h1 {
     .gauge:focus-visible,
     .mini-card:focus-visible { outline: 2px solid var(--heading); outline-offset: 4px; }
 
-    @media (min-width: 768px) {
-      .load-container { flex-direction: row; align-items: center; }
-      .gauge { width: 200px; height: 200px; }
-      .load-cards { flex: 1; flex-direction: row; }
-      .load-cards .mini-card { flex: 1; }
+    @media (min-width:768px) {
+      .load-container { grid-template-columns:1fr 1fr; gap:var(--gap-4); }
     }
 
-    @media (max-width: 600px) {
-      .load-container { align-items: stretch; }
-      .gauge { width: 140px; height: 140px; }
+    @media (min-width:1024px) {
+      .load-container { grid-template-columns:1.4fr 1fr; gap:var(--gap-5); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .gauge .progress,
+      .mini-bar-row .fill { transition: none; }
     }
 
     @media screen and (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Rework load average card into responsive grid-based layout
- Implement dynamic donut gauge with ResizeObserver-driven stroke sizing
- Add mini-stat cards with trend icons and shared progress bar styling

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eeb1efa1c832d9b07baaf0fc63899