### PR TITLE
feat: enhance load bar visuals

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1327,7 +1327,10 @@ function renderMini(label, load, prevLoad, cores) {
     valEl.textContent = '—';
     fill.style.width = '0%';
     fill.className = 'fill';
-    trend.textContent = 'donnée manquante';
+    trend.innerHTML = 'donnée manquante';
+    trend.style.color = 'var(--text-muted)';
+    trend.removeAttribute('title');
+    trend.removeAttribute('aria-label');
     card.removeAttribute('title');
     card.removeAttribute('aria-label');
     bar.removeAttribute('aria-label');
@@ -1344,7 +1347,13 @@ function renderMini(label, load, prevLoad, cores) {
     });
     dot.style.background = status.color;
     const t = trendFrom(load, prevLoad);
-    trend.textContent = t.label;
+    trend.innerHTML = `<i class="fa-solid ${t.icon}" aria-hidden="true"></i><span>${t.label}</span>`;
+    let trendColor = 'var(--text-muted)';
+    if (t.icon === 'fa-chevron-up') trendColor = 'var(--success)';
+    else if (t.icon === 'fa-chevron-down') trendColor = 'var(--danger)';
+    trend.style.color = trendColor;
+    trend.setAttribute('aria-label', t.label);
+    trend.title = t.label;
     const rawStr = load.toLocaleString('fr-FR', {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1005,12 +1005,20 @@ h1 {
 
     .mini-card { display:flex; flex-direction:column; gap:var(--gap-1); }
     .mini-card.na { opacity:0.5; }
-    .mini-title { font-size:var(--font-sm); display:flex; align-items:center; gap:0.4rem; }
+    .mini-title { font-size:var(--font-md); display:flex; align-items:center; gap:0.4rem; }
     .status-dot { width:0.6rem; height:0.6rem; border-radius:50%; background:var(--ok); }
     .mini-bar-row { display:flex; align-items:center; gap:var(--gap-1); }
     .mini-bar-row .bar { flex:1; }
-    .mini-val { font-weight:600; font-size:var(--font-sm); }
-    .mini-trend { font-size:var(--font-sm); opacity:0.8; }
+    .mini-val { font-weight:600; font-size:var(--font-md); }
+    .mini-trend {
+      font-size:var(--font-sm);
+      opacity:0.8;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      gap:var(--gap-1);
+    }
+    .mini-trend i { font-size:var(--font-md); }
 
 .kpi { width:200px; height:200px; border-radius:50%; display:grid; place-items:center; }
 @media (max-width:600px){ .kpi { width:150px; height:150px; } }
@@ -1170,6 +1178,12 @@ h1 {
       font-weight: 600;
       white-space: nowrap;
     }
+
+    .load-cards .bar {
+      height: 20px;
+      border-radius: 10px;
+    }
+    .load-cards .bar .fill { border-radius: 10px; }
 
     /* Mémoire : barre dédiée, non impactée par .bar générique */
     .mem .bar.mem-bar {


### PR DESCRIPTION
## Summary
- enlarge 5/15 min load bars and align styles
- add trend chevrons with accessible labels
- bump load bar label fonts for readability

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_689eeee6f5f0832d8263a43e0b206650