### PR TITLE
feat: check required commands

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# ✅ Commandes requises
+REQUIRED_CMDS=(mpstat sensors jq bc docker)
+for cmd in "${REQUIRED_CMDS[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "❌ Commande requise manquante : $cmd" >&2
+    exit 1
+  fi
+done
+
 # 🛠 Script de génération de rapport d'audit système
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 


### PR DESCRIPTION
## Summary
- ensure `generate-audit-json.sh` fails fast when required utilities are missing

## Testing
- ⚠️ `./generate-audit-json.sh` (missing `mpstat`)
- ⚠️ `./tests/run.sh` (missing `mpstat`)


------
https://chatgpt.com/codex/tasks/task_e_689f027ff72c832daab2391a5341887e