### PR TITLE
Limit public IP fetch duration with fallback

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -30,7 +30,8 @@ HOSTNAME=$(hostname)
 
 # 🌐 Réseau
 IP_LOCAL=$(hostname -I | awk '{print $1}')
-IP_PUBLIQUE=$(curl -s ifconfig.me || echo "N/A")
+# IP publique avec délai max 5s ; N/A si la requête échoue
+IP_PUBLIQUE=$(curl -s --max-time 5 ifconfig.me 2>/dev/null || echo "N/A")
 
 # 🧠 RAM & Swap
 MEMORY=$(free -h | awk 'NR==2 {print "{\"total\":\""$2"\",\"used\":\""$3"\",\"free\":\""$4"\",\"shared\":\""$5"\",\"buff_cache\":\""$6"\",\"available\":\""$7"\"}"}')


### PR DESCRIPTION
## Summary
- Use a 5-second max timeout when requesting the public IP address and fall back to `N/A` if it fails

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f038d98a4832d8299e980492ba199