### PR TITLE
Improve port parsing in audit script

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -65,7 +65,7 @@ TOP_CPU=$(ps -eo pid,comm,%cpu,%mem --sort=-%cpu | head -n 6 | jq -Rn '[inputs |
 TOP_MEM=$(ps -eo pid,comm,%mem,%cpu --sort=-%mem | head -n 6 | jq -Rn '[inputs | split(" ") | map(select(length > 0)) | select(length >= 4) | {"pid": .[0], "cmd": .[1], "mem": .[2], "cpu": .[3]}]')
 
 # 🌐 Ports ouverts
-PORTS=$(ss -tuln | awk 'NR>1 {print $1, $5}' \
+PORTS=$(ss -tuln | awk 'NR>1 {split($5,a,":" ); port=a[length(a)]; if (port ~ /^[0-9]+$/) print $1, port}' \
   | jq -Rn '[inputs | split(" ") | map(select(length>0)) | select(length==2) | {"proto": .[0], "port": .[1]}]')
 
 # 📦 Conversion d'unités en octets


### PR DESCRIPTION
## Summary
- ensure `ss` port parsing handles IPv4 and IPv6
- skip lines without numeric ports when building port list

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f0466d0e0832db9a37ecb1c80f53e