### PR TITLE
Use configurable audit paths

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+AUDIT_DIR=/home/damswallace/docker/audits-nginx

--- a/README.md
+++ b/README.md
@@ -27,17 +27,18 @@ interface that can be served by Nginx.
    ./generate-audit-json.sh
    ```
 
-The script writes reports to `/home/damswallace/docker/audits-nginx/audits/archives` by default. Override the
-location by setting the `BASE_DIR` environment variable:
+By default, the script writes reports to `./audits/archives`. Override the location by setting the `BASE_DIR`
+environment variable:
 
 ```bash
-BASE_DIR=./audits ./generate-audit-json.sh
+BASE_DIR=/path/to/audits ./generate-audit-json.sh
 ```
 
 ## 🌐 Serving the reports
 
 Use the provided `docker-compose.yaml` and `nginx.conf` to serve the `audits` directory through Nginx and expose
-it behind Traefik. Adjust volume paths or labels as needed for your environment. Run:
+it behind Traefik. Set `AUDIT_DIR` in `.env` to point to the directory containing `audits` and `nginx.conf`, then
+start the service:
 
 ```bash
 docker compose up -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: nginx:alpine
     container_name: audit-server
     volumes:
-      - /home/damswallace/docker/audits-nginx/audits:/usr/share/nginx/html:ro
-      - /home/damswallace/docker/audits-nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${AUDIT_DIR}/audits:/usr/share/nginx/html:ro
+      - ${AUDIT_DIR}/nginx.conf:/etc/nginx/nginx.conf:ro
     expose:
       - "80"  # Pas de publication sur le host
     restart: unless-stopped

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,8 +8,7 @@ This guide explains how to serve audit reports through Nginx running in Docker w
    ./generate-audit-json.sh
    ```
 
-   Reports are stored under `/home/damswallace/docker/audits-nginx/audits/archives` by default. Use `BASE_DIR` to
-   change the location.
+   Reports are stored under `./audits/archives` by default. Use `BASE_DIR` to change the location.
 
 2. Start the container:
 
@@ -17,6 +16,6 @@ This guide explains how to serve audit reports through Nginx running in Docker w
    docker compose up -d
    ```
 
-The `docker-compose.yaml` mounts the audit directory and `nginx.conf`, exposes port 80 on the `br-dams` network
-and sets Traefik labels for routing `audit.damswallace.fr`. Adjust paths, network settings or labels to fit your
-environment.
+The `docker-compose.yaml` uses an `AUDIT_DIR` variable from `.env` to mount the audit directory and `nginx.conf`,
+exposes port 80 on the `br-dams` network and sets Traefik labels for routing `audit.damswallace.fr`. Adjust
+paths, network settings or labels to fit your environment.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,11 +21,10 @@ This document provides extra details on how to use the audit script and serve th
 ## 📊 Generating reports
 
 The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports
-are stored under `/home/damswallace/docker/audits-nginx/audits`. You can override this location by setting the
-`BASE_DIR` environment variable:
+are stored under `./audits`. You can override this location by setting the `BASE_DIR` environment variable:
 
 ```bash
-BASE_DIR=./audits ./generate-audit-json.sh
+BASE_DIR=/path/to/audits ./generate-audit-json.sh
 ```
 
 Each execution creates a timestamped file in `archives/` and refreshes `index.json` with the list of available
@@ -33,8 +32,8 @@ reports.
 
 ## 📂 Serving reports
 
-Use the provided Docker and Nginx setup to serve the `audits` directory. Adjust paths or Traefik labels in
-`docker-compose.yaml` to match your environment:
+Use the provided Docker and Nginx setup to serve the `audits` directory. Set `AUDIT_DIR` in `.env` to point to
+your audit directory, then adjust any Traefik labels in `docker-compose.yaml` to match your environment:
 
 ```bash
 docker compose up -d

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -18,7 +18,7 @@ TIMESTAMP=$(date "+%Y-%m-%d_%H-%M")
 HUMAN_DATE=$(date "+%d/%m/%Y à %H:%M")
 
 # 📁 Dossiers (modifiable avec la variable d'environnement BASE_DIR)
-BASE_DIR="${BASE_DIR:-/home/damswallace/docker/audits-nginx/audits}"
+BASE_DIR="${BASE_DIR:-./audits}"
 ARCHIVE_DIR="$BASE_DIR/archives"
 OUTPUT_FILE="${ARCHIVE_DIR}/audit_${TIMESTAMP}.json"
 mkdir -p "$ARCHIVE_DIR"


### PR DESCRIPTION
## Summary
- Default audit output directory to `./audits`
- Parameterize docker volumes via `AUDIT_DIR` in `.env`
- Document new paths and environment variables

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f1d220490832d91d3cafb2c6e6eb7