### PR TITLE
Add CI workflow and audit validation tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+audits/scripts/viewer.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y sysstat lm-sensors jq bc shellcheck
+      - run: npm run lint
+      - run: npm test
+      - run: shellcheck generate-audit-json.sh

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "esbuild audits/scripts/main.js --bundle --outfile=audits/scripts/viewer.js",
     "lint": "eslint \"audits/scripts/**/*.js\"",
-    "format": "prettier -w \"audits/scripts/**/*.js\""
+    "format": "prettier -w \"audits/scripts/**/*.js\"",
+    "test": "./tests/run.sh"
   },
   "devDependencies": {
     "esbuild": "^0.19.0",


### PR DESCRIPTION
## Summary
- add npm test script
- extend audit test to validate key fields across multiple reports
- introduce CI workflow running lint, tests, and shellcheck

## Testing
- `npm run lint`
- `npm test`
- `shellcheck generate-audit-json.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f21401d48832d9d82e7ae5b6fca5b