### PR TITLE
Fix Docker memory display percentage

### DIFF
--- a/audits/scripts/modules/docker.js
+++ b/audits/scripts/modules/docker.js
@@ -121,7 +121,8 @@ function renderDockerList() {
     const badge = health
       ? `<span class="status-badge status-${health}">${health}</span>`
       : '';
-    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div>${badge}</div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div><span class="bar-value">${c.cpu}%</span></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div><span class="bar-value">${c.memText || c.mem + '%'}%</span></div></div>`;
+    const memDisplay = c.memText || `${c.mem}%`;
+    card.innerHTML = `<div class="docker-head"><div class="docker-title"><span class="docker-icon">${icon}</span><span class="docker-name">${c.name}</span></div>${badge}</div><div class="docker-uptime">${c.uptime}</div><div class="docker-bars"><div class="bar-outer cpu"><div class="fill ${cpuColor}"></div><span class="bar-value">${c.cpu}%</span></div><div class="bar-outer ram"><div class="fill ${ramColor}"></div><span class="bar-value">${memDisplay}</span></div></div>`;
     frag.appendChild(card);
     updates.push({ fills: card.querySelectorAll('.fill'), cpu: c.cpu, mem: c.mem });
   });


### PR DESCRIPTION
## Summary
- Avoid appending an extra % when Docker container memory text is provided

## Testing
- `npm test` *(fails: Commande requise manquante : mpstat)*
- `node --input-type=module` sample rendering to visually verify memText and default percent

------
https://chatgpt.com/codex/tasks/task_e_689f304652c4832dbee2dd4f29db2b40