### PR TITLE
feat(ui): add disk usage details

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1262,6 +1262,10 @@ function renderDisks(disks){
         <circle class="donut-ring ${colorClassDisk(pctRaw)}" cx="20" cy="20" r="16" stroke-dasharray="0 100"></circle>
         <text x="20" y="20" class="donut-value">${pctDisplay}%</text>
       </svg>
+      <div class="disk-info">
+        <span>${usedStr} utilisés</span>
+        <span>${freeStr} libres</span>
+      </div>
       <div class="disk-badges">
         <span class="badge">${disk.mountpoint}</span>
         <span class="badge">${totalStr}</span>

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1297,6 +1297,7 @@ h1 {
     .disk-donut .donut-ring.color-danger { stroke:var(--crit); }
     .disk-donut .donut-ring:hover { stroke-width:5; }
     .donut-value { fill:var(--text); font-size:0.7rem; font-weight:700; text-anchor:middle; dominant-baseline:middle; }
+    .disk-info { display:flex; justify-content:space-between; margin-top:var(--gap-2); font-size:var(--font-sm); }
     .disk-badges { display:flex; justify-content:space-between; margin-top:var(--gap-2); }
     .disk-tooltip { position:absolute; top:0; left:0; background:var(--bg-card); color:var(--text); padding:4px 8px; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.2); font-size:var(--font-sm); white-space:nowrap; opacity:0; pointer-events:none; transition:opacity .2s; z-index:20; }
     .disk-card.show-tooltip .disk-tooltip { opacity:1; }


### PR DESCRIPTION
## Summary
- show used and free space below each disk gauge
- add styling for new disk information row

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f325e86d8832da0d909f5bc1b5b2c