### PR TITLE
Refactor open ports report

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -212,16 +212,14 @@
   <div id="dockerEmpty" class="empty hidden">Aucun conteneur actif</div>
   <h2><i class="fa-solid fa-plug heading-icon"></i>Ports ouverts <span id="portsTotal" class="badge badge-total">0</span></h2>
   <p class="subtitle">Interfaces et services détectés</p>
-  <div id="portsLegend" class="ports-legend"></div>
+  <div id="portsSummary" class="ports-summary"></div>
   <div class="ports-toolbar">
-    <input type="text" id="portSearch" placeholder="Filtrer… ex. 22, ssh, 0.0.0.0" />
+    <input type="text" id="portSearch" placeholder="Filtrer… ex : 22, ssh, 0.0.0.0" />
     <div id="portFilters" class="filter-chips"></div>
-    <select id="portSort">
-      <option value="port-asc">Port ↑</option>
-      <option value="port-desc">Port ↓</option>
-      <option value="service">Service A→Z</option>
-      <option value="risk">Risque</option>
-    </select>
+    <div id="portSortToggle" class="sort-toggle">
+      <button data-sort="risk" class="active">Par criticité</button>
+      <button data-sort="port">Par port</button>
+    </div>
     <button id="portsCopy" class="btn" title="Copier tous"><i class="fa-solid fa-copy"></i></button>
   </div>
   <div id="portsContainer" class="block-wrapper"></div>

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -916,28 +916,24 @@ h1 {
     }
     .mem .badge[data-tip] { position: relative; }
     .mem .spark { width: 60px; height: 20px; }
-    .ports-legend {
-      font-size: 0.9rem;
-      margin: 0.5rem 0;
+    .ports-summary {
       display: flex;
       flex-wrap: wrap;
       gap: 0.5rem;
-      color: var(--muted);
+      margin: 0.5rem 0;
     }
-    .ports-legend span {
-      display: flex;
-      align-items: center;
-      gap: 0.2rem;
+    .summary-item {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 8px;
+      padding: 0.25rem 0.6rem;
+      box-shadow: var(--card-shadow);
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
     }
-    .risk-dot {
-      width: 0.8rem;
-      height: 0.8rem;
-      border-radius: 50%;
-      display: inline-block;
-    }
-    .risk-dot.low { background: var(--success); }
-    .risk-dot.medium { background: var(--warning); }
-    .risk-dot.high { background: var(--danger); }
+    .summary-item.critical { background: var(--danger); color: #fff; }
+    .summary-item.warning { background: var(--warning); color: #000; }
+    .summary-item.low { background: var(--success); color: #000; }
     .ports-toolbar {
       display: flex;
       flex-wrap: wrap;
@@ -946,27 +942,39 @@ h1 {
       align-items: center;
     }
     #portSearch { flex: 1; min-width: 180px; }
-    #portSort { background: var(--card-bg); color: var(--text); border: 1px solid var(--card-border); padding: 0.25rem; border-radius: 4px; }
-    .port-accordion { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 8px; margin-bottom: 0.5rem; box-shadow: var(--card-shadow); overflow: hidden; }
-    .port-accordion + .port-accordion { margin-top: 0.5rem; }
-    .accordion-header { background: var(--card-bg); width: 100%; text-align: left; padding: 0.4rem 0.6rem; border: none; color: var(--text); display: flex; justify-content: space-between; align-items: center; cursor: pointer; }
-    .accordion-header .count { background: var(--chip-bg); border-radius:6px; padding:2px 8px; font-family:var(--font-mono); }
-    .accordion-content { display: none; padding:0.4rem; background: var(--card-bg); }
-    .port-accordion.open > .accordion-content { display:block; }
-    .ip-accordion { background: var(--card-bg); border:1px solid var(--card-border); border-radius:8px; margin:0.3rem 0; overflow:hidden; }
-    .ip-accordion.open > .accordion-content { display:block; }
-    .ip-accordion .accordion-header { background: var(--card-bg); }
-    .port-line { display:flex; align-items:center; gap:0.5rem; padding:0.2rem 0.3rem; font-size:0.9rem; flex-wrap:wrap; }
-    .port-line .service-name { flex:1; font-weight:500; }
-    .port-line .port-mono { font-family:var(--font-mono); }
-    .port-line .badges { margin-left:auto; display:flex; gap:0.2rem; flex-wrap:wrap; }
-    .port-line .badge { font-size:0.7rem; padding:0.1rem 0.3rem; }
-    .port-line .risk-dot { margin-left:0.3rem; }
-    .port-line .copy-btn { margin-left:0.3rem; }
+    .sort-toggle { display: flex; border-radius: 6px; overflow: hidden; }
+    .sort-toggle button {
+      background: var(--chip-bg);
+      color: var(--chip-text);
+      border: none;
+      padding: 0.25rem 0.6rem;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .sort-toggle button.active { background: var(--chip-active-bg); color: var(--bg); }
+    .service-group { background: var(--card-bg); border: 1px solid var(--card-border); border-radius: 8px; box-shadow: var(--card-shadow); margin-bottom: 0.5rem; }
+    .service-group.collapsed .service-body { display: none; }
+    .service-header { width: 100%; display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.6rem; background: none; border: none; color: var(--text); cursor: pointer; text-align: left; }
+    .service-header .icon { font-size: 1.2rem; }
+    .service-header .title { flex: 1; }
+    .service-header .count { background: var(--chip-bg); border-radius:6px; padding:2px 8px; font-family:var(--font-mono); }
+    .service-body { padding: 0.4rem; display: flex; flex-direction: column; gap: 0.3rem; }
+    .port-item { display:flex; align-items:center; gap:0.5rem; padding:0.2rem 0.3rem; font-size:0.9rem; flex-wrap:wrap; border-left:4px solid transparent; }
+    .port-item .port-label { font-family:var(--font-mono); font-weight:500; }
+    .port-item .badges { display:flex; gap:0.2rem; flex-wrap:wrap; }
+    .port-item .instances { margin-left:auto; font-size:0.8rem; color:var(--muted); }
+    .port-item button { margin-left:auto; }
+    .port-item.critical { border-color: var(--danger); }
+    .port-item.warning { border-color: var(--warning); }
+    .port-item.docker { border-color: var(--info); }
+    .port-item.low { border-color: var(--success); }
+    .critical-chip { border:1px solid var(--danger); }
+    .critical-chip.active { background: var(--danger); color:#fff; }
 
     @media (max-width: 600px) {
-      .port-line { flex-direction: column; align-items: flex-start; }
-      .port-line .badges { margin-left: 0; }
+      .port-item { flex-direction: column; align-items: flex-start; }
+      .port-item .badges { margin-left: 0; }
+      .service-header { flex-wrap: wrap; }
     }
 
     .load-container {


### PR DESCRIPTION
## Summary
- group open port data by service and show a compact summary bar
- add risk-aware sorting, critical filter chip and deduplicate port instances
- restyle open port cards for visual parity with other report sections

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a182b019c0832d9bf6e8b6b1cb71f6