### PR TITLE
feat: add OS report section and version checks

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -87,6 +87,10 @@
   </div>
 
   <main>
+  <h2 id="osTitle"><i class="fa-solid fa-desktop heading-icon"></i>Système d’exploitation</h2>
+  <div id="osCard" class="info-card card" aria-labelledby="osTitle">
+    <div id="osContent" class="card-body"></div>
+  </div>
   <h2 id="networkTitle"><i class="fa-solid fa-network-wired heading-icon"></i>Adressage réseau</h2>
   <div class="info-card card network-card" id="networkCard" aria-labelledby="networkTitle">
     <div class="card-body">

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -407,6 +407,11 @@ h1 {
       pointer-events: auto;
     }
 
+    .update-badge.warning {
+      background: var(--warning);
+      color: #000;
+    }
+
     .update-badge:hover,
     .update-badge:focus {
       box-shadow: 0 4px 12px rgba(0,0,0,.25);
@@ -766,6 +771,25 @@ h1 {
 .network-card .copy-btn:focus-visible {
   background: var(--ip-color);
   color: var(--bg);
+}
+
+.os-card .card-body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--gap-2);
+}
+
+.os-item {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-1);
+}
+
+.os-label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-1);
 }
 
     .disk-bar-container {

--- a/docs/REPORT_STRUCTURE.md
+++ b/docs/REPORT_STRUCTURE.md
@@ -3,6 +3,15 @@
 The `generate-audit-json.sh` script outputs a JSON file summarizing system metrics. The top-level object
 contains:
 
+- `report_version`: version of the generator used to produce the report.
+- `schema_version`: integer identifying the JSON schema version.
+- `os`: details about the operating system (may be absent).
+- `os.name`: distribution name (e.g. `Ubuntu`).
+- `os.version`: distribution version string.
+- `os.codename`: distribution codename if available.
+- `os.kernel`: kernel version (from `uname -r`).
+- `os.architecture`: machine architecture (from `uname -m`).
+- `os.kernel_boot_time`: kernel boot time in ISO 8601, when available.
 - `generated`: human-readable timestamp of report generation.
 - `hostname`: system hostname.
 - `ip_local`: first local IP address.
@@ -34,6 +43,15 @@ A minimal example:
 
 ```json
 {
+  "report_version": "1.4.0",
+  "schema_version": 2,
+  "os": {
+    "name": "Ubuntu",
+    "version": "24.04.2 LTS",
+    "codename": "Noble Numbat",
+    "kernel": "6.8.0-40-generic",
+    "architecture": "x86_64"
+  },
   "generated": "01/01/2024 à 12:00",
   "hostname": "server1",
   "ip_local": "192.168.1.10",


### PR DESCRIPTION
## Summary
- include generator and schema versions plus OS details in audit JSON
- display OS section in viewer with version compatibility warnings
- document new fields in report structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1887b62e0832dafb3598a20c316d9