### PR TITLE
Bump audit report schema version to 3

### DIFF
--- a/docs/REPORT_STRUCTURE.md
+++ b/docs/REPORT_STRUCTURE.md
@@ -4,7 +4,7 @@ The `generate-audit-json.sh` script outputs a JSON file summarizing system metri
 contains:
 
 - `report_version`: version of the generator used to produce the report.
-- `schema_version`: integer identifying the JSON schema version.
+- `schema_version`: integer identifying the JSON schema version (currently 3).
 - `os`: details about the operating system (may be absent).
 - `os.name`: distribution name (e.g. `Ubuntu`).
 - `os.version`: distribution version string.
@@ -42,11 +42,11 @@ contains:
 A minimal example:
 
 ```json
-{
-  "report_version": "1.4.0",
-  "schema_version": 2,
-  "os": {
-    "name": "Ubuntu",
+  {
+   "report_version": "1.4.0",
+   "schema_version": 3,
+   "os": {
+     "name": "Ubuntu",
     "version": "24.04.2 LTS",
     "codename": "Noble Numbat",
     "kernel": "6.8.0-40-generic",

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -9,7 +9,7 @@ BASE_DIR="${BASE_DIR:-$(pwd)/audits}"
 
 # 🔢 Versionning du générateur et du schéma
 REPORT_VERSION="1.4.0"
-SCHEMA_VERSION=2
+SCHEMA_VERSION=3
 
 # ✅ Commandes requises
 REQUIRED_CMDS=(mpstat sensors jq bc docker)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,6 +18,7 @@ done
 
 for file in "${files[@]}"; do
   jq empty "$file"
+  jq -e '.schema_version == 3' "$file" >/dev/null
   jq -e '.cpu.model | length > 0' "$file" >/dev/null
   jq -e '.cpu.cores | tonumber > 0' "$file" >/dev/null
   jq -e '.ports | type == "array"' "$file" >/dev/null


### PR DESCRIPTION
## Summary
- align generated report schema with UI expectations
- document current schema version and update example
- verify generated reports use schema version 3 in tests

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a1900b64f8832da166ea087c92b516