### PR TITLE
Refactor sidebar navigation into compact timeline

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -54,27 +54,31 @@
       </div>
 
       <div class="report-grid">
-        <button id="btnLatest" class="btn primary">
-          <span><i class="fa-solid fa-bolt"></i></span>
-          <span class="label">Voir le dernier rapport</span>
-          <small id="latestInfo" class="subinfo"></small>
-        </button>
+        <div id="latestCard" class="latest-card" role="button" tabindex="0" aria-label="Ouvrir le dernier rapport">
+          <div class="latest-text">
+            <div class="latest-title">Dernier rapport</div>
+            <div id="latestInfo" class="latest-details"></div>
+          </div>
+          <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+        </div>
 
-        <div class="day-control" role="group" aria-label="Choisir un jour">
-          <button id="dayToday" class="seg">Aujourd'hui</button>
-          <button id="dayYesterday" class="seg">Hier</button>
-          <button id="dayCalendar" class="seg" aria-label="Choisir une date" title="Choisir une date"><i class="fa-solid fa-calendar"></i></button>
-          <input type="date" id="datePicker" class="sr-only" />
+        <div class="day-nav">
+          <button id="prevDay" class="nav-arrow" aria-label="Jour précédent">◀</button>
+          <div class="day-control" role="group" aria-label="Choisir un jour">
+            <button id="dayToday" class="seg">Aujourd'hui</button>
+            <button id="dayYesterday" class="seg">Hier</button>
+            <button id="dayCalendar" class="seg" aria-label="Choisir une date" title="Choisir une date"><i class="fa-solid fa-calendar"></i></button>
+            <input type="date" id="datePicker" class="sr-only" />
+          </div>
+          <button id="nextDay" class="nav-arrow" aria-label="Jour suivant">▶</button>
         </div>
 
         <div id="selectorStatus" aria-live="polite"></div>
 
         <div class="timeline-wrapper">
-          <div id="timeTimeline" class="timeline" aria-live="polite"></div>
+          <div id="timeList" class="timeline" aria-live="polite"></div>
         </div>
       </div>
-
-      <span id="refreshDot" class="refresh-dot" aria-label="Actualisation automatique" title="Actualisation automatique"></span>
     </div>
   </aside>
   <div id="menuOverlay"></div>

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -229,26 +229,27 @@ h1 {
   margin-bottom: var(--gap-4);
 }
 
-    #btnLatest {
+
+    .latest-card {
       display: flex;
-      align-items: flex-start;
-      justify-content: center;
-      flex-direction: column;
-      font-size: 1rem;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.5rem 0.75rem;
+      background: var(--bg-card);
+      border-radius: 6px;
+      cursor: pointer;
     }
 
-    #btnLatest i { margin-right: 0.5rem; }
-    #btnLatest .label { font-weight: bold; }
-    #btnLatest .subinfo {
-      font-size: 0.8rem;
-      opacity: 0.8;
-    }
+    .latest-card:hover { background: #333; }
+    .latest-card:active { background: #444; }
+    .latest-card .latest-title { font-weight: bold; }
+    .latest-card .latest-details { font-size: 0.8rem; opacity: 0.8; }
 
-    .report-grid {
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
-    }
+      .report-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
 
     @media (min-width: 601px) {
       .report-grid {
@@ -261,103 +262,96 @@ h1 {
           "timeline";
         gap: 0.5rem;
       }
-      #btnLatest { grid-area: btn; }
-      .day-control { grid-area: day; }
+      #latestCard { grid-area: btn; }
+      .day-nav { grid-area: day; }
       #selectorStatus { grid-area: status; }
       .timeline-wrapper { grid-area: timeline; }
     }
 
-    .day-control {
-      display: flex;
-      border: 1px solid #555;
-      border-radius: 6px;
-      overflow: hidden;
-    }
+      .day-nav {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+      }
 
-    .day-control .seg {
-      background: transparent;
-      color: var(--text);
-      padding: 0.5rem 0.8rem;
-      border: none;
-      cursor: pointer;
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+      .day-control {
+        display: flex;
+        border: 1px solid #555;
+        border-radius: 6px;
+        overflow: hidden;
+      }
 
-    .day-control .seg:hover { background: #333; }
-    .day-control .seg:active { background: #444; }
-    .day-control .seg.active {
-      background: var(--heading);
-      color: var(--bg);
-    }
+      .day-control .seg {
+        background: transparent;
+        color: var(--text);
+        padding: 0.5rem 0.8rem;
+        border: none;
+        cursor: pointer;
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
 
-    .day-control .seg:focus-visible {
-      outline: 2px solid var(--heading);
-      outline-offset: -2px;
-    }
+      .nav-arrow {
+        background: transparent;
+        border: 1px solid #555;
+        color: var(--text);
+        padding: 0.5rem 0.6rem;
+        border-radius: 6px;
+        cursor: pointer;
+      }
 
-    .timeline-wrapper {
-      overflow-x: auto;
-      padding: 0.5rem;
-    }
+      .nav-arrow:hover { background: #333; }
+      .nav-arrow:active { background: #444; }
 
-    .timeline { display: flex; gap: 0.5rem; }
+      .day-control .seg:hover { background: #333; }
+      .day-control .seg:active { background: #444; }
+      .day-control .seg.active {
+        background: var(--heading);
+        color: var(--bg);
+      }
 
-    .time-chip {
-      background: #444;
-      color: var(--text);
-      border: none;
-      border-radius: 9999px;
-      padding: 0.4rem 0.8rem;
-      cursor: pointer;
-      white-space: nowrap;
-      font-family: var(--font-mono);
-    }
+      .day-control .seg:focus-visible {
+        outline: 2px solid var(--heading);
+        outline-offset: -2px;
+      }
 
-    .time-chip:hover { background: #555; }
-    .time-chip:active { background: #666; }
-
-    .time-chip.active {
-      background: var(--heading);
-      color: var(--bg);
-    }
-
-    @media (min-width: 1024px) {
       .timeline-wrapper {
-        overflow-x: visible;
+        overflow-y: auto;
+        padding: 0.5rem;
       }
-      .timeline {
-        flex-wrap: wrap;
-      }
+
+      .timeline { display: flex; flex-direction: column; gap: 0.25rem; }
+
       .time-chip {
-        flex: 1 1 45%;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        background: transparent;
+        color: var(--text);
+        border: none;
+        border-radius: 4px;
+        padding: 0.4rem 0.6rem;
+        cursor: pointer;
+        font-family: var(--font-mono);
+        text-align: left;
       }
-    }
 
-    .time-chip:focus-visible {
-      outline: 2px solid var(--heading);
-      outline-offset: 4px;
-    }
+      .time-chip:hover { background: #333; }
+      .time-chip:active { background: #444; }
 
-    .refresh-dot {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      background: var(--subheading);
-      opacity: 0.5;
-      position: absolute;
-      top: 10px;
-      right: 10px;
-    }
+      .time-chip.active {
+        background: var(--heading);
+        color: var(--bg);
+      }
 
-    .refresh-dot.active { animation: blink 1s ease-in-out infinite; }
+      .time-chip:focus-visible {
+        outline: 2px solid var(--heading);
+        outline-offset: -2px;
+      }
 
-    @keyframes blink {
-      0%, 100% { opacity: 0.3; }
-      50% { opacity: 1; }
-    }
+      /* removed refresh dot */
 
     .update-badge {
       position: fixed;


### PR DESCRIPTION
## Summary
- replace auto-refresh badge and latest report button with compact "Dernier rapport" card
- add previous/next day controls and scrollable vertical hour list
- emit events and remove refresh-dot logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a6117ea0832d908670b2671e785f