### PR TITLE
fix: load reports relative to current path

### DIFF
--- a/audits/scripts/modules/audits.js
+++ b/audits/scripts/modules/audits.js
@@ -6,12 +6,12 @@ export let auditsMap = {};
 export let latestEntry = null;
 
 export async function fetchIndex() {
-  const res = await fetch('/archives/index.json');
+  const res = await fetch('archives/index.json');
   return await res.json();
 }
 
 export async function loadAudit(file) {
-  const res = await fetch('/archives/' + file);
+  const res = await fetch('archives/' + file);
   if (!res.ok) throw new Error('Fichier inaccessible');
   return await res.json();
 }

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -753,13 +753,13 @@ function renderDocker(list){
 }
 
 async function fetchIndex() {
-  const res = await fetch('/archives/index.json');
+  const res = await fetch('archives/index.json');
   return await res.json();
 }
 
 async function loadAudit(file) {
   try {
-    const res = await fetch('/archives/' + file);
+    const res = await fetch('archives/' + file);
     if (!res.ok) throw new Error('Fichier inaccessible');
     return await res.json();
   } catch (err) {


### PR DESCRIPTION
## Summary
- load archives index and reports with relative URLs so the sidebar can fetch reports correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f41d6af0832d9165a4d1235cb5f3