### PR TITLE
fix: remove duplicate BASE_DIR

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -29,7 +29,6 @@ TIMESTAMP=$(date "+%Y-%m-%d_%H-%M")
 HUMAN_DATE=$(date "+%d/%m/%Y à %H:%M")
 
 # 📁 Dossiers (modifiable avec la variable d'environnement BASE_DIR)
-BASE_DIR="${BASE_DIR:-./audits}"
 ARCHIVE_DIR="$BASE_DIR/archives"
 OUTPUT_FILE="${ARCHIVE_DIR}/audit_${TIMESTAMP}.json"
 mkdir -p "$ARCHIVE_DIR"


### PR DESCRIPTION
## Summary
- ensure generate-audit-json uses single BASE_DIR definition

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a30731cf70832da5a812a0483d1de4