### PR TITLE
feat: make Docker optional in audit generator

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,6 +18,9 @@ This document provides extra details on how to use the audit script and serve th
    sudo apt-get install -y bc jq curl lm-sensors sysstat
    ```
 
+Docker n'est pas requis. Si Docker est disponible sur le système,
+le script ajoutera simplement les statistiques des conteneurs au rapport.
+
 ## 📊 Generating reports
 
 The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -11,8 +11,8 @@ BASE_DIR="${BASE_DIR:-$(pwd)/audits}"
 REPORT_VERSION="1.4.0"
 SCHEMA_VERSION=3
 
-# ✅ Commandes requises
-REQUIRED_CMDS=(mpstat sensors jq bc docker)
+# ✅ Commandes requises (Docker est géré séparément)
+REQUIRED_CMDS=(mpstat sensors jq bc)
 for cmd in "${REQUIRED_CMDS[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "❌ Commande requise manquante : $cmd" >&2
@@ -128,7 +128,7 @@ collect_services() {
   echo "${services:-[]}"
 }
 
-# 🐳 Docker
+# 🐳 Docker (si installé)
 DOCKER_CONTAINERS="[]"
 if command -v docker >/dev/null 2>&1; then
   declare -A CPU MEM_PCT MEM_USED MEM_LIMIT


### PR DESCRIPTION
## Summary
- treat Docker as optional by removing it from required command checks
- document optional Docker usage in audit server docs

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a308519cc4832da53ac65aada8e098