### PR TITLE
Fix binary units in audit report generation

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -69,6 +69,7 @@ PORTS=$(ss -tuln | awk 'NR>1 {split($5,a,":" ); port=a[length(a)]; if (port ~ /^
   | jq -Rn '[inputs | split(" ") | map(select(length>0)) | select(length==2) | {"proto": .[0], "port": .[1]}]')
 
 # 📦 Conversion d'unités en octets
+# Les unités KB, MB et GB sont interprétées en base 1024
 to_bytes() {
   local input="$1"
   local num unit factor
@@ -76,9 +77,9 @@ to_bytes() {
   unit=$(echo "$input" | tr ',' '.' | sed -E 's/[0-9\.]+(.*)/\1/')
   case "$unit" in
     B)   factor=1 ;;
-    KB)  factor=1000 ;;
-    MB)  factor=1000000 ;;
-    GB)  factor=1000000000 ;;
+    KB)  factor=1024 ;;
+    MB)  factor=$((1024*1024)) ;;
+    GB)  factor=$((1024*1024*1024)) ;;
     KiB) factor=1024 ;;
     MiB) factor=$((1024*1024)) ;;
     GiB) factor=$((1024*1024*1024)) ;;


### PR DESCRIPTION
## Summary
- Treat KB/MB/GB as base 1024 in `generate-audit-json.sh`
- Document that non-IEC suffixes are interpreted in base 1024

## Testing
- `./tests/run.sh`
- `source <(sed -n '71,89p' generate-audit-json.sh); for val in 1KB 1MB 1GB; do echo "$val -> $(to_bytes $val)"; done; mem=$(free -h | awk 'NR==2 {print $2}' | sed -e 's/Gi/GiB/' -e 's/Mi/MiB/' -e 's/Ki/KiB/'); printf 'free -h total %s -> %s\n' "$mem" "$(to_bytes $mem)"`


------
https://chatgpt.com/codex/tasks/task_e_68a30968f070832d8d85cd219c5e0e60