### PR TITLE
fix: init reports when DOM is already loaded

### DIFF
--- a/audits/scripts/main.js
+++ b/audits/scripts/main.js
@@ -1,3 +1,7 @@
 import { init } from './modules/audits.js';
 
-document.addEventListener('DOMContentLoaded', init);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -444,5 +444,9 @@
   }
 
   // audits/scripts/main.js
-  document.addEventListener("DOMContentLoaded", init);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
 })();


### PR DESCRIPTION
## Summary
- initialise audit viewer immediately if DOM is ready to avoid missing reports
- rebuild viewer bundle

## Testing
- `npm test` *(fails: Commande requise manquante : mpstat)*

------
https://chatgpt.com/codex/tasks/task_e_68a30fb5a9bc832d9a805025fc0cf21f