### PR TITLE
Fix viewer path and enable sidebar toggle

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-  <script src="/scripts/viewer.js?v=3" defer></script>
+  <script src="scripts/viewer.js?v=3" defer></script>
 </head>
   <body data-theme="dark">
   <header id="topBar" class="top-bar">

--- a/audits/scripts/modules/audits.js
+++ b/audits/scripts/modules/audits.js
@@ -1,6 +1,7 @@
 import { renderServices } from './services.js';
 import { renderDocker } from './docker.js';
 import { parseIndex, getLatest, groupByDay } from './timeline.js';
+import { setupSidebar } from './ui.js';
 
 export let auditsIndex = [];
 export let auditsMap = {};
@@ -25,6 +26,7 @@ export function showStatus(message, type) {
 }
 
 export async function init() {
+  setupSidebar();
   try {
     showStatus('Chargement…', 'loading');
     const list = await fetchIndex();

--- a/audits/scripts/modules/ui.js
+++ b/audits/scripts/modules/ui.js
@@ -70,3 +70,15 @@ export function adjustBarValue(valueEl, fillEl, val) {
   }
   valueEl.style.color = contrastColor(bg);
 }
+
+export function setupSidebar() {
+  const sidebar = document.getElementById('sidebar');
+  const toggle = document.getElementById('menuToggle');
+  const overlay = document.getElementById('menuOverlay');
+  if (!sidebar || !toggle || !overlay) return;
+  const close = () => sidebar.classList.remove('open');
+  toggle.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
+  });
+  overlay.addEventListener('click', close);
+}

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -229,6 +229,18 @@
       return "color-warning";
     return "color-danger";
   }
+  function setupSidebar() {
+    const sidebar = document.getElementById("sidebar");
+    const toggle = document.getElementById("menuToggle");
+    const overlay = document.getElementById("menuOverlay");
+    if (!sidebar || !toggle || !overlay)
+      return;
+    const close = () => sidebar.classList.remove("open");
+    toggle.addEventListener("click", () => {
+      sidebar.classList.toggle("open");
+    });
+    overlay.addEventListener("click", close);
+  }
 
   // audits/scripts/modules/docker.js
   var dockerData = [];
@@ -423,6 +435,7 @@
     div.textContent = message || "";
   }
   async function init() {
+    setupSidebar();
     try {
       showStatus("Chargement\u2026", "loading");
       const list = await fetchIndex();


### PR DESCRIPTION
## Summary
- Load viewer bundle with a relative path so scripts run regardless of base URL
- Add sidebar toggle helpers and wire them during init to restore left menu interaction

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a312a180f4832d924616d7883ef502