### PR TITLE
Handle missing /home in audit script

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -37,7 +37,11 @@ IP_PUBLIQUE=$(curl -s --max-time 5 ifconfig.me 2>/dev/null || echo "N/A")
 
 # 💽 Disques
 DISK_ROOT=$(df -h / | awk 'NR==2 {print "{\"filesystem\":\""$1"\",\"size\":\""$2"\",\"used\":\""$3"\",\"available\":\""$4"\",\"used_percent\":\""$5"\",\"mountpoint\":\""$6"\"}"}')
-DISK_HOME=$(df -h /home | awk 'NR==2 {print "{\"filesystem\":\""$1"\",\"size\":\""$2"\",\"used\":\""$3"\",\"available\":\""$4"\",\"used_percent\":\""$5"\",\"mountpoint\":\""$6"\"}"}')
+if [ -d /home ]; then
+  DISK_HOME=$(df -h /home | awk 'NR==2 {print "{\"filesystem\":\""$1"\",\"size\":\""$2"\",\"used\":\""$3"\",\"available\":\""$4"\",\"used_percent\":\""$5"\",\"mountpoint\":\""$6"\"}"}')
+else
+  DISK_HOME=null
+fi
 
 # 🔧 Processus gourmands
 TOP_CPU=$(ps -eo pid,comm,%cpu,%mem --sort=-%cpu | head -n 6 | jq -Rn '[inputs | split(" ") | map(select(length > 0)) | select(length >= 4) | {"pid": .[0], "cmd": .[1], "cpu": .[2], "mem": .[3]}]')

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,18 +4,43 @@ set -euo pipefail
 tmp_dir=$(mktemp -d)
 files=()
 
-for i in 1 2; do
-  base="$tmp_dir/run$i"
-  BASE_DIR="$base" ./generate-audit-json.sh >/tmp/test_audit.log
-  archive_dir="$base/archives"
-  file=$(ls "$archive_dir"/audit_*.json | head -n 1)
-  if [ ! -f "$file" ]; then
-    echo "No audit file generated for run $i" >&2
-    exit 1
-  fi
-  files+=("$file")
-done
+# Run with existing /home
+base="$tmp_dir/with_home"
+BASE_DIR="$base" ./generate-audit-json.sh >/tmp/test_audit.log
+archive_dir="$base/archives"
+file=$(ls "$archive_dir"/audit_*.json | head -n 1)
+if [ ! -f "$file" ]; then
+  echo "No audit file generated with /home present" >&2
+  exit 1
+fi
+files+=("$file")
 
+# Run without /home
+backup_dir=$(mktemp -d)
+if [ -d /home ]; then
+  mv /home "$backup_dir/home"
+fi
+base="$tmp_dir/without_home"
+BASE_DIR="$base" ./generate-audit-json.sh >/tmp/test_audit.log
+archive_dir="$base/archives"
+file=$(ls "$archive_dir"/audit_*.json | head -n 1)
+if [ ! -f "$file" ]; then
+  echo "No audit file generated without /home" >&2
+  mv "$backup_dir/home" /home 2>/dev/null || true
+  exit 1
+fi
+files+=("$file")
+if [ -d "$backup_dir/home" ]; then
+  mv "$backup_dir/home" /home
+fi
+rmdir "$backup_dir"
+
+# Validate disk entries for both scenarios
+jq -e '.disks | length > 1' "${files[0]}" >/dev/null
+jq -e '.disks[1] != null' "${files[0]}" >/dev/null
+jq -e '.disks[1] == null' "${files[1]}" >/dev/null
+
+# Generic checks
 for file in "${files[@]}"; do
   jq empty "$file"
   jq -e '.cpu.model | length > 0' "$file" >/dev/null


### PR DESCRIPTION
## Summary
- avoid running `df -h /home` when `/home` directory is absent
- extend tests to verify audit generation with and without `/home`

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a3223a4768832db33fbe7df4f759f3