### PR TITLE
Ensure audit reports use script-relative path for cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ interface that can be served by Nginx.
    ./generate-audit-json.sh
    ```
 
-By default, the script writes reports to `./audits/archives`. Override the location by setting the `BASE_DIR`
-environment variable:
+By default, the script writes reports to `audits/archives` next to the script, ensuring the path remains
+consistent even when invoked from cron. Override the location by setting the `BASE_DIR` environment variable:
 
 ```bash
 BASE_DIR=/path/to/audits ./generate-audit-json.sh

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,7 +21,8 @@ This document provides extra details on how to use the audit script and serve th
 ## 📊 Generating reports
 
 The `generate-audit-json.sh` script collects system information and writes it as JSON files. By default, reports
-are stored under `./audits`. You can override this location by setting the `BASE_DIR` environment variable:
+are stored under `audits` next to the script, so running it from cron or other directories uses the same location.
+You can override this location by setting the `BASE_DIR` environment variable:
 
 ```bash
 BASE_DIR=/path/to/audits ./generate-audit-json.sh

--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -20,7 +20,10 @@ TIMESTAMP=$(date "+%Y-%m-%d_%H-%M")
 HUMAN_DATE=$(date "+%d/%m/%Y à %H:%M")
 
 # 📁 Dossiers (modifiable avec la variable d'environnement BASE_DIR)
-BASE_DIR="${BASE_DIR:-./audits}"
+# Le chemin de base est ancré sur le dossier contenant ce script afin que
+# l'exécution via cron génère les rapports au bon endroit.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="${BASE_DIR:-"$SCRIPT_DIR/audits"}"
 ARCHIVE_DIR="$BASE_DIR/archives"
 OUTPUT_FILE="${ARCHIVE_DIR}/audit_${TIMESTAMP}.json"
 mkdir -p "$ARCHIVE_DIR"


### PR DESCRIPTION
## Summary
- Anchor audit output path to the script directory so cron jobs store JSON reports in the expected `audits/archives` folder
- Update README and usage docs to explain script-relative paths

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ad77aba73c832da3b1da99e87631e8