### PR TITLE
fix: replace duplicate port copy buttons

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -565,8 +565,12 @@ function renderPortsTable(){
     row.appendChild(riskTd);
 
     const actTd = document.createElement('td');
-    actTd.appendChild(createCopyButton('Copier résumé', () => buildSummary(p)));
-    actTd.appendChild(createCopyButton('Copier mitigation', () => buildMitigation(p)));
+    actTd.appendChild(
+      createCopyButton(
+        'Copier résumé et mitigation',
+        () => `${buildSummary(p)}\n${buildMitigation(p)}`
+      )
+    );
     row.appendChild(actTd);
 
     const detailRow = document.createElement('tr');


### PR DESCRIPTION
## Summary
- combine port summary and mitigation copy actions into single button

## Testing
- `./tests/run.sh` *(fails: Commande requise manquante : mpstat)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc65cb48832dae9b7741a459c5d1