### PR TITLE
Remove unused risk legend from open ports table

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -231,7 +231,6 @@
     <tbody id="portsBody"></tbody>
   </table>
   <div id="portsEmpty" class="empty hidden">Aucun port ne correspond. <button id="portsReset" class="btn">Réinitialiser</button></div>
-  <div id="riskLegend" class="risk-legend"></div>
   </main>
   <script>
     const themeSwitch = document.getElementById("themeToggle");

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -589,10 +589,6 @@ function initPortsUI(){
     applyPortFilters();
   });
 
-  const legend = document.getElementById('riskLegend');
-  if (legend) {
-    legend.innerHTML = PORT_RISKS.map(r => `<span class="badge risk-${r}">${r}</span>`).join(' ');
-  }
 }
 
 function renderPorts(list){

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -922,7 +922,6 @@ h1 {
     .bindings-table { width:100%; border-collapse:collapse; margin-top:0.5rem; }
     .bindings-table th, .bindings-table td { padding:0.2rem 0.3rem; border-bottom:1px solid var(--card-border); font-size:0.85rem; }
     .bindings-table tbody tr:nth-child(even) { background:rgba(255,255,255,0.03); }
-    .risk-legend { margin-top:0.5rem; display:flex; gap:0.5rem; font-size:0.8rem; }
     .badge.risk-critical { background:var(--crit); color:#fff; }
     .badge.risk-warn { background:var(--warn); color:#000; }
     .badge.risk-local { background:var(--info); color:#fff; }


### PR DESCRIPTION
## Summary
- remove risk legend div under open ports table
- drop associated JavaScript initialization
- prune risk legend CSS styling

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aec55bccc8832da7fe0a0ad3a93e24