### PR TITLE
Avoid missing count spans in service and Docker views

### DIFF
--- a/audits/scripts/modules/docker.js
+++ b/audits/scripts/modules/docker.js
@@ -103,7 +103,7 @@ function renderDockerList() {
   const grid = document.getElementById('dockerGrid');
   grid.textContent = '';
   const countSpan = document.getElementById('dockerCount');
-  countSpan.textContent = dockerFiltered.length;
+  if (countSpan) countSpan.textContent = dockerFiltered.length;
   if (!dockerFiltered.length) {
     document.getElementById('dockerEmpty').classList.remove('hidden');
     return;

--- a/audits/scripts/modules/services.js
+++ b/audits/scripts/modules/services.js
@@ -105,7 +105,7 @@ function renderServicesList() {
   const list = document.getElementById('servicesList');
   list.textContent = '';
   const countSpan = document.getElementById('servicesCount');
-  countSpan.textContent = filteredServices.length;
+  if (countSpan) countSpan.textContent = filteredServices.length;
   if (filteredServices.length === 0) {
     document.getElementById('servicesEmpty').classList.remove('hidden');
     return;

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -100,7 +100,8 @@
     const list = document.getElementById("servicesList");
     list.textContent = "";
     const countSpan = document.getElementById("servicesCount");
-    countSpan.textContent = filteredServices.length;
+    if (countSpan)
+      countSpan.textContent = filteredServices.length;
     if (filteredServices.length === 0) {
       document.getElementById("servicesEmpty").classList.remove("hidden");
       return;
@@ -330,7 +331,8 @@
     const grid = document.getElementById("dockerGrid");
     grid.textContent = "";
     const countSpan = document.getElementById("dockerCount");
-    countSpan.textContent = dockerFiltered.length;
+    if (countSpan)
+      countSpan.textContent = dockerFiltered.length;
     if (!dockerFiltered.length) {
       document.getElementById("dockerEmpty").classList.remove("hidden");
       return;


### PR DESCRIPTION
## Summary
- Safeguard updates to service count span to avoid null reference errors
- Safeguard Docker container count updates and mirror checks in viewer script

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aecaa18b50832d88731744611440b7