### PR TITLE
Fix report selection menu and UI styling

### DIFF
--- a/audits/audits.js
+++ b/audits/audits.js
@@ -44,6 +44,97 @@ export function showStatus(message, type) {
   div.textContent = message || '';
 }
 
+async function loadAndRender(file) {
+  try {
+    showStatus('Chargement…', 'loading');
+    const data = await loadAudit(file);
+    renderAudit(data);
+    renderServices(data.services || []);
+    renderDocker(data.docker || []);
+    showStatus('');
+  } catch (err) {
+    console.error(err);
+    showStatus('Impossible de charger les rapports', 'error');
+  }
+}
+
+function selectDay(date, activeTime) {
+  const timeline = document.getElementById('timeTimeline');
+  timeline.textContent = '';
+  const list = auditsMap[date];
+  if (!list || list.length === 0) {
+    showStatus('Aucun rapport', 'empty');
+    return;
+  }
+  list.forEach((entry) => {
+    const chip = document.createElement('button');
+    chip.className = 'time-chip';
+    chip.textContent = entry.time;
+    if (entry.time === activeTime) chip.classList.add('active');
+    chip.addEventListener('click', () => {
+      document
+        .querySelectorAll('#timeTimeline .time-chip')
+        .forEach((c) => c.classList.remove('active'));
+      chip.classList.add('active');
+      loadAndRender(entry.file);
+    });
+    timeline.appendChild(chip);
+  });
+  showStatus('');
+}
+
+function setupSelector() {
+  const btnLatest = document.getElementById('btnLatest');
+  const latestInfo = document.getElementById('latestInfo');
+  const dayToday = document.getElementById('dayToday');
+  const dayYesterday = document.getElementById('dayYesterday');
+  const dayCalendar = document.getElementById('dayCalendar');
+  const datePicker = document.getElementById('datePicker');
+  const buttons = [dayToday, dayYesterday, dayCalendar];
+  const setActiveDay = (btn) => {
+    buttons.forEach((b) => b && b.classList.remove('active'));
+    if (btn) btn.classList.add('active');
+  };
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const yest = new Date();
+  yest.setDate(today.getDate() - 1);
+  const yestStr = yest.toISOString().slice(0, 10);
+  if (latestEntry && latestInfo)
+    latestInfo.textContent = `${latestEntry.date} ${latestEntry.time}`;
+  btnLatest?.addEventListener('click', () => {
+    selectDay(latestEntry.date, latestEntry.time);
+    setActiveDay(
+      latestEntry.date === todayStr
+        ? dayToday
+        : latestEntry.date === yestStr
+          ? dayYesterday
+          : dayCalendar,
+    );
+    loadAndRender(latestEntry.file);
+  });
+  dayToday?.addEventListener('click', () => {
+    selectDay(todayStr);
+    setActiveDay(dayToday);
+  });
+  dayYesterday?.addEventListener('click', () => {
+    selectDay(yestStr);
+    setActiveDay(dayYesterday);
+  });
+  dayCalendar?.addEventListener('click', () => {
+    if (datePicker.showPicker) datePicker.showPicker();
+    else datePicker.click();
+  });
+  datePicker?.addEventListener('change', (e) => {
+    selectDay(e.target.value);
+    setActiveDay(dayCalendar);
+  });
+  selectDay(latestEntry.date, latestEntry.time);
+  if (latestEntry.date === todayStr) setActiveDay(dayToday);
+  else if (latestEntry.date === yestStr) setActiveDay(dayYesterday);
+  else setActiveDay(dayCalendar);
+}
+
 export async function init() {
   try {
     showStatus('Chargement…', 'loading');
@@ -53,12 +144,9 @@ export async function init() {
       showStatus('Aucun rapport', 'empty');
       return;
     }
-    const data = await loadAudit(latestEntry.file);
-    renderAudit(data);
-    renderServices(data.services || []);
-    renderDocker(data.docker || []);
+    setupSelector();
+    await loadAndRender(latestEntry.file);
     initMenu();
-    showStatus('');
   } catch (err) {
     console.error(err);
     showStatus('Impossible de charger les rapports', 'error');

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -670,7 +670,7 @@ h1 {
       background-color: var(--success);
       transition: width 0.5s ease, background-color 0.5s ease;
     }
- .badge,
+.badge,
 .pill {
   display:inline-flex;
   align-items:center;
@@ -684,6 +684,7 @@ h1 {
   color:var(--text);
 }
 .pill { font-weight:600; }
+.badge:empty { display:none; }
 /* removed old load-header styles */
     .color-success { background-color: var(--success); color: white; }
     .color-warning { background-color: var(--warning); color: black; }
@@ -1266,6 +1267,11 @@ h1 {
     .disk-badges { display:flex; justify-content:space-between; margin-top:var(--gap-2); }
     .disk-tooltip { position:absolute; top:0; left:0; background:var(--bg-card); color:var(--text); padding:4px 8px; border-radius:4px; box-shadow:0 2px 6px rgba(0,0,0,0.2); font-size:var(--font-sm); white-space:nowrap; opacity:0; pointer-events:none; transition:opacity .2s; z-index:20; }
     .disk-card.show-tooltip .disk-tooltip { opacity:1; }
+    .cpu-model { font-weight:600; margin-bottom:var(--gap-2); }
+    .cpu-core { font-family:var(--font-mono); }
+    .mem-card { background:var(--block-bg); border:1px solid var(--card-border); border-radius:8px; padding:var(--gap-3); box-shadow:var(--card-shadow); }
+    .proc-item { padding:4px 0; border-bottom:1px solid var(--border); }
+    .proc-item:last-child { border-bottom:none; }
     .cpu .card-head { display:flex; align-items:center; justify-content:space-between; gap:var(--gap-2); flex-wrap:wrap; }
     .cpu .summary { display:flex; gap:var(--gap-2); flex-wrap:wrap; }
     .cpu .summary .badge { white-space:nowrap; }


### PR DESCRIPTION
## Summary
- Add interactive report selector with day and time options
- Hide empty badges to avoid stray circle in top bar
- Style CPU, memory and process lists for clearer layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aefcc5b648832d9e96a4ea82079882