### PR TITLE
fix: robust load parsing and DOM safeguards

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -27,7 +27,8 @@ mkdir -p "$ARCHIVE_DIR"
 
 # 🔍 Infos système
 UPTIME=$(uptime -p)
-LOAD_AVG=$(uptime | awk -F'load average:' '{print $2}' | sed 's/ //g')
+# Normalize load average: capture numbers, convert commas to dots, join with commas
+LOAD_AVG=$(uptime | grep -o '[0-9][0-9]*[.,][0-9]*' | head -n3 | tr ',' '.' | paste -sd, -)
 HOSTNAME=$(hostname)
 
 # 🌐 Réseau


### PR DESCRIPTION
## Summary
- handle load averages regardless of locale by using regex-based parsing
- add array and null checks in render helpers to avoid console errors
- normalize load average generation in `generate-audit-json.sh`

## Testing
- `./tests/run.sh`
- `node - <<'NODE'
const parseValues = (val) => {
  if (!val && val !== 0) return [null, null, null];
  if (Array.isArray(val)) {
    const a = val.slice(0,3).map(x => typeof x === 'number' ? x : parseFloat(String(x).replace(',', '.')));
    while (a.length < 3) a.push(null);
    return a;
  }
  const m = String(val).match(/\d+(?:[.,]\d+)?/g) || [];
  const out = m.slice(0,3).map(s => {
    const n = parseFloat(s.replace(',', '.'));
    return Number.isFinite(n) ? n : null;
  });
  while (out.length < 3) out.push(null);
  return out;
};
console.log(parseValues("0.68,0.70,0.54"));
console.log(parseValues("0,76,0,94,0,83"));
console.log(parseValues(["0.1","0,2",0.3]));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68af0bb3118c832daa8cf6c9fe038f17