### PR TITLE
Fix load average parsing

### DIFF
--- a/generate-audit-json.sh
+++ b/generate-audit-json.sh
@@ -27,8 +27,8 @@ mkdir -p "$ARCHIVE_DIR"
 
 # 🔍 Infos système
 UPTIME=$(uptime -p)
-# Normalize load average: capture numbers, convert commas to dots, join with commas
-LOAD_AVG=$(uptime | grep -o '[0-9][0-9]*[.,][0-9]*' | head -n3 | tr ',' '.' | paste -sd, -)
+# Load averages from /proc to avoid locale-dependent parsing of `uptime`
+LOAD_AVG=$(awk '{printf "%s,%s,%s", $1+0, $2+0, $3+0}' /proc/loadavg)
 HOSTNAME=$(hostname)
 
 # 🌐 Réseau


### PR DESCRIPTION
## Summary
- avoid capturing uptime timestamps when parsing load average
- read load averages from /proc to prevent malformed values in JSON output

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af114e4398832d8bd0797c21bb5983