### PR TITLE
docs: reset to v1.2.0 and update guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.2.0] - 2025-08-27
+
+- Project reset to release v1.2.0. All development that occurred after this tag has been removed.
+- Contains Bash audit script, static viewer and optional Docker/Nginx deployment.
+
+Earlier versions are not covered in this repository snapshot.
+

--- a/README.md
+++ b/README.md
@@ -1,67 +1,70 @@
 # Audit Server
 
-This project provides a lightweight way to collect and view system audit reports. A Bash script gathers
-metrics such as CPU usage, memory consumption, open ports, running services, and Docker container stats,
-then writes the results to JSON files. Static files under `audits` display the reports through a simple web
-interface that can be served by Nginx.
+**Version 1.2.0** – this repository reflects the state of the project at release v1.2.0. All work that occurred
+after this tag has been discarded.
 
-## 🚀 Installation
+Audit Server generates periodic JSON reports describing the state of a host and exposes them through a static web
+viewer. The solution is composed of three parts:
 
-1. 📥 Clone the repository
+* `generate-audit-json.sh` – Bash script that collects metrics (CPU, memory, disks, services, open ports and
+  Docker containers) and stores them as timestamped JSON files.
+* `audits/` – static HTML, CSS and JavaScript viewer that loads and renders those JSON files in a browser.
+* `docker-compose.yaml` and `nginx.conf` – optional container setup to serve the viewer with Nginx.
+
+The front‑end code is written as ES modules and bundled with [esbuild](https://esbuild.github.io/). Development
+dependencies such as `esbuild`, `eslint` and `prettier` are listed in `package.json`.
+
+## 📦 Prerequisites
+
+The audit script relies on a handful of system utilities:
+
+```text
+bc, jq, curl, lm-sensors, sysstat (for mpstat), ss, awk, sed and grep
+```
+
+Docker is optional; if it is available, container statistics are included in the report. Node.js is required only
+when rebuilding the front‑end bundle.
+
+## 🛠️ Installation
+
+1. Clone the repository:
 
    ```bash
    git clone https://github.com/your-org/audit-server.git
    cd audit-server
    ```
 
-2. 🧰 Install dependencies
+2. Install the required packages listed above using your distribution’s package manager.
 
-   ```bash
-   sudo apt-get update
-   sudo apt-get install -y bc jq curl lm-sensors sysstat
-   ```
-
-3. ▶️ Generate your first audit
+3. Generate a first report:
 
    ```bash
    ./generate-audit-json.sh
    ```
 
-By default, the script writes reports to `audits/archives` next to the script, ensuring the path remains
-consistent even when invoked from cron. Override the location by setting the `BASE_DIR` environment variable:
+   Reports are written to `audits/archives` next to the script. Set `BASE_DIR` to use a different directory:
 
-```bash
-BASE_DIR=/path/to/audits ./generate-audit-json.sh
-```
+   ```bash
+   BASE_DIR=/path/to/audits ./generate-audit-json.sh
+   ```
+
+For more detailed installation steps, see [docs/INSTALLATION.md](docs/INSTALLATION.md).
 
 ## 🌐 Serving the reports
 
-Use the provided `docker-compose.yaml` and `nginx.conf` to serve the `audits` directory through Nginx and expose
-it behind Traefik. Set `AUDIT_DIR` in `.env` to point to the directory containing `audits` and `nginx.conf`, then
-start the service:
+The repository includes a minimal Nginx setup. After creating at least one report, serve the viewer with Docker
+Compose:
 
 ```bash
 docker compose up -d
 ```
 
-## 🗂️ Directory structure
-
-```
-├── audits               # Web interface and generated reports
-├── generate-audit-json.sh
-├── docker-compose.yaml
-└── nginx.conf
-```
-
-## 📚 Documentation
-
-Additional usage instructions are available in the [docs](docs/USAGE.md) directory. Deployment options are
-covered in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md). Details about the JSON audit report structure can be
-found in [docs/REPORT_STRUCTURE.md](docs/REPORT_STRUCTURE.md).
+`AUDIT_DIR` in `.env` must point to the directory containing `audits` and `nginx.conf`. Traefik labels in the
+compose file route requests to the container; adjust them to match your environment.
 
 ## 🧪 Testing
 
-Run the provided test script to generate a sample report and validate its JSON structure:
+Run the test suite to verify that the audit generator produces a valid JSON file:
 
 ```bash
 ./tests/run.sh
@@ -69,8 +72,7 @@ Run the provided test script to generate a sample report and validate its JSON s
 
 ## 🛠️ Development
 
-JavaScript assets are split into ES modules and bundled for the browser. Install Node.js
-dependencies and use the provided npm scripts:
+If you modify the JavaScript modules under `audits/scripts`, rebuild the bundled viewer and run the linters:
 
 ```bash
 npm install
@@ -78,6 +80,12 @@ npm run build   # bundle front-end scripts
 npm run lint    # run ESLint
 npm run format  # format sources with Prettier
 ```
+
+## 📚 Additional documentation
+
+* [docs/USAGE.md](docs/USAGE.md) – operating the audit script and viewer
+* [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) – Docker/Nginx deployment guide
+* [docs/REPORT_STRUCTURE.md](docs/REPORT_STRUCTURE.md) – JSON report reference
 
 ## 📄 License
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,6 +1,7 @@
 # 🚀 Deployment Guide
 
-This guide explains how to serve audit reports through Nginx running in Docker with Traefik.
+This guide explains how to serve audit reports through Nginx running in Docker with Traefik. It applies to
+Audit Server version 1.2.0.
 
 1. Generate audits (or schedule the script):
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,61 @@
+# 🛠️ Installation Guide
+
+This guide explains how to set up Audit Server version 1.2.0 from scratch.
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/your-org/audit-server.git
+cd audit-server
+```
+
+## 2. Install required packages
+
+The audit script depends on common GNU utilities and a few monitoring tools. Install them with your package
+manager:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y bc jq curl lm-sensors sysstat iproute2
+```
+
+> `ss`, `awk`, `sed` and `grep` are provided by the base system. Docker is optional but enables container
+> statistics in the reports.
+
+## 3. Generate a report
+
+Run the generator once to create the directory structure and the first JSON report:
+
+```bash
+./generate-audit-json.sh
+```
+
+By default, reports are stored under `audits/archives`. To place them elsewhere, use the `BASE_DIR` environment
+variable:
+
+```bash
+BASE_DIR=/path/to/audits ./generate-audit-json.sh
+```
+
+## 4. View reports
+
+Open `audits/index.html` in a browser or serve the directory using the provided Docker Compose configuration:
+
+```bash
+docker compose up -d
+```
+
+Set `AUDIT_DIR` in `.env` to the path that contains the `audits` folder and `nginx.conf`.
+
+## 5. Optional: rebuild front‑end assets
+
+If you change files under `audits/scripts`, install Node.js dependencies and rebuild the bundle:
+
+```bash
+npm install
+npm run build
+```
+
+The repository already includes a prebuilt bundle, so these commands are only required when modifying the
+JavaScript sources.
+

--- a/docs/REPORT_STRUCTURE.md
+++ b/docs/REPORT_STRUCTURE.md
@@ -1,7 +1,7 @@
 # 🧾 Audit Report Structure
 
-The `generate-audit-json.sh` script outputs a JSON file summarizing system metrics. The top-level object
-contains:
+The `generate-audit-json.sh` script outputs a JSON file summarizing system metrics. This specification describes
+the format used in Audit Server version 1.2.0. The top-level object contains:
 
 - `generated`: human-readable timestamp of report generation.
 - `hostname`: system hostname.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,22 +1,7 @@
 # 📘 Audit Server Documentation
 
-This document provides extra details on how to use the audit script and serve the resulting reports.
-
-## 🚀 Installation
-
-1. 📥 Clone the repository
-
-   ```bash
-   git clone https://github.com/your-org/audit-server.git
-   cd audit-server
-   ```
-
-2. 🧰 Install dependencies
-
-   ```bash
-   sudo apt-get update
-   sudo apt-get install -y bc jq curl lm-sensors sysstat
-   ```
+This document provides extra details on how to use the audit script and serve the resulting reports. It applies to
+version 1.2.0 of the project. For installation instructions, see [INSTALLATION.md](INSTALLATION.md).
 
 ## 📊 Generating reports
 


### PR DESCRIPTION
## Summary
- document that repository reflects release v1.2.0 and outline project components
- add dedicated installation guide and changelog
- update usage, deployment, and report structure docs for v1.2.0

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af2e6f5ebc832dbdfc77044ea73a6c