### PR TITLE
Refactor open ports responsive layout

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -216,20 +216,19 @@
   <div class="ports-actions">
     <input type="text" id="portSearch" placeholder="Rechercher un port ou un service…" aria-label="Rechercher un port ou un service…" />
   </div>
-  <table id="portsTable" class="ports-table">
-    <thead>
-      <tr>
-        <th data-sort="port">Port</th>
-        <th data-sort="service">Service</th>
-        <th>Catégorie</th>
-        <th>Exposition</th>
-        <th>Processus</th>
-        <th class="bindings-header">Bindings</th>
-        <th data-sort="risk">Risque</th>
-      </tr>
-    </thead>
-    <tbody id="portsBody"></tbody>
-  </table>
+  <div id="portsTable" class="ports-table">
+    <div class="ports-header ports-row">
+      <div data-sort="port">Port</div>
+      <div data-sort="service">Service</div>
+      <div>Catégorie</div>
+      <div>Exposition</div>
+      <div class="col-processus">Processus</div>
+      <div class="col-bindings">Bindings</div>
+      <div data-sort="risk">Risque</div>
+    </div>
+    <div id="portsBody" class="ports-body"></div>
+  </div>
+  <div id="portsCards" class="ports-cards"></div>
   <div id="portsEmpty" class="empty hidden">Aucun port ne correspond. <button id="portsReset" class="btn">Réinitialiser</button></div>
   </main>
   <script>

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -346,11 +346,33 @@ let sortKey = 'risk';
 let sortDir = 1;
 let portsInit = false;
 
+function formatPort(proto, port){
+  return `${proto}/${port}`;
+}
+
+function firstService(services){
+  return services && services.length ? services[0] : 'unknown';
+}
+
+function uniqueScopes(scopes){
+  const order = ['Public', 'Docker', 'Localhost'];
+  const set = new Set(scopes || []);
+  return order.filter(s => set.has(s));
+}
+
+function riskToBadge(level){
+  return `badge risk-${level}`;
+}
+
+function categoryToBadge(cat){
+  return `badge badge-${cat}`;
+}
+
 function renderPortDetails(p){
   const wrap = document.createElement('div');
   const info = document.createElement('div');
   const reasons = p.risk.reasons.join(' + ');
-  info.className = 'details-info';
+  info.className = 'wrap details-title';
   info.textContent = `Services: ${p.services.join(', ')}${reasons ? ' — ' + reasons : ''}`;
   wrap.appendChild(info);
   const table = document.createElement('table');
@@ -456,81 +478,131 @@ function toggleRow(row, detail){
 
 function renderPortsTable(){
   const tbody = document.getElementById('portsBody');
+  const cards = document.getElementById('portsCards');
   tbody.textContent = '';
+  cards.textContent = '';
   if (!filteredPorts.length){
     document.getElementById('portsEmpty').classList.remove('hidden');
     return;
   }
   document.getElementById('portsEmpty').classList.add('hidden');
   filteredPorts.forEach(p => {
-    const row = document.createElement('tr');
-    row.className = 'port-row';
+    const row = document.createElement('div');
+    row.className = 'ports-row';
     row.tabIndex = 0;
+    row.setAttribute('role', 'button');
     row.setAttribute('aria-expanded', 'false');
 
-    const portTd = document.createElement('td');
-    portTd.textContent = `${p.proto}/${p.port}`;
-    row.appendChild(portTd);
+    const portDiv = document.createElement('div');
+    portDiv.textContent = formatPort(p.proto, p.port);
+    row.appendChild(portDiv);
 
-    const svcTd = document.createElement('td');
-    const svc = p.services[0] || '';
-    svcTd.textContent = svc;
-    if (p.services.length > 1){
-      const more = document.createElement('span');
-      more.className = 'more-svc';
-      more.textContent = ` (+${p.services.length - 1})`;
-      svcTd.appendChild(more);
-    }
-    row.appendChild(svcTd);
+    const svcDiv = document.createElement('div');
+    svcDiv.className = 'truncate';
+    const svc = firstService(p.services);
+    svcDiv.textContent = svc;
+    svcDiv.title = svc;
+    row.appendChild(svcDiv);
 
-    const catTd = document.createElement('td');
+    const catDiv = document.createElement('div');
     const catMeta = PORT_CATS.find(c => c.key === p.category);
     const catBadge = document.createElement('span');
-    catBadge.className = `badge cat-${p.category}`;
+    catBadge.className = categoryToBadge(p.category);
     catBadge.textContent = catMeta ? catMeta.label : p.category;
-    catTd.appendChild(catBadge);
-    row.appendChild(catTd);
+    catDiv.appendChild(catBadge);
+    row.appendChild(catDiv);
 
-    const scopeTd = document.createElement('td');
-    p.scopes.forEach(s => {
-      const b = document.createElement('span');
-      b.className = 'badge scope-badge';
-      b.textContent = s;
-      scopeTd.appendChild(b);
+    const scopeDiv = document.createElement('div');
+    scopeDiv.className = 'chips';
+    uniqueScopes(p.scopes).forEach(s => {
+      const chip = document.createElement('span');
+      chip.className = `chip chip-${s.toLowerCase()}`;
+      chip.textContent = s;
+      scopeDiv.appendChild(chip);
     });
-    row.appendChild(scopeTd);
+    row.appendChild(scopeDiv);
 
-    const procTd = document.createElement('td');
-    procTd.textContent = p.counts.processes;
-    row.appendChild(procTd);
+    const procDiv = document.createElement('div');
+    procDiv.className = 'col-processus';
+    procDiv.textContent = p.counts.processes;
+    row.appendChild(procDiv);
 
-    const bindTd = document.createElement('td');
-    bindTd.className = 'bindings-cell';
-    bindTd.textContent = p.counts.bindings;
-    row.appendChild(bindTd);
+    const bindDiv = document.createElement('div');
+    bindDiv.className = 'col-bindings';
+    bindDiv.textContent = p.counts.bindings;
+    row.appendChild(bindDiv);
 
-    const riskTd = document.createElement('td');
+    const riskDiv = document.createElement('div');
     const riskBadge = document.createElement('span');
-    riskBadge.className = `badge risk-${p.risk.level}`;
+    riskBadge.className = riskToBadge(p.risk.level);
     riskBadge.textContent = p.risk.level;
     if (p.risk.reasons && p.risk.reasons.length) riskBadge.title = p.risk.reasons.join(' + ');
-    riskTd.appendChild(riskBadge);
-    row.appendChild(riskTd);
+    riskDiv.appendChild(riskBadge);
+    row.appendChild(riskDiv);
 
-    const detailRow = document.createElement('tr');
-    detailRow.className = 'details-row hidden';
+    const detailRow = document.createElement('div');
+    detailRow.className = 'row-details hidden';
     detailRow.setAttribute('aria-hidden', 'true');
-    const detailTd = document.createElement('td');
-    detailTd.colSpan = 7;
-    detailTd.appendChild(renderPortDetails(p));
-    detailRow.appendChild(detailTd);
+    detailRow.appendChild(renderPortDetails(p));
 
     const toggle = () => toggleRow(row, detailRow);
     row.addEventListener('click', toggle);
-    bindTd.addEventListener('click', e => { e.stopPropagation(); toggle(); });
+    row.addEventListener('keydown', e => { if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggle(); } });
+    bindDiv.addEventListener('click', e => { e.stopPropagation(); toggle(); });
 
     tbody.appendChild(row);
     tbody.appendChild(detailRow);
+
+    const card = document.createElement('div');
+    card.className = 'port-card';
+    card.tabIndex = 0;
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-expanded', 'false');
+
+    const title = document.createElement('div');
+    title.className = 'title';
+    const left = document.createElement('span');
+    left.textContent = `${formatPort(p.proto, p.port)} • ${firstService(p.services)}`;
+    const right = document.createElement('span');
+    const rb = document.createElement('span');
+    rb.className = riskToBadge(p.risk.level);
+    rb.textContent = p.risk.level;
+    if (p.risk.reasons && p.risk.reasons.length) rb.title = p.risk.reasons.join(' + ');
+    right.appendChild(rb);
+    title.appendChild(left);
+    title.appendChild(right);
+    card.appendChild(title);
+
+    const chipsLine = document.createElement('div');
+    chipsLine.className = 'chips';
+    const catB = document.createElement('span');
+    catB.className = categoryToBadge(p.category);
+    catB.textContent = catMeta ? catMeta.label : p.category;
+    chipsLine.appendChild(catB);
+    uniqueScopes(p.scopes).forEach(s => {
+      const chip = document.createElement('span');
+      chip.className = `chip chip-${s.toLowerCase()}`;
+      chip.textContent = s;
+      chipsLine.appendChild(chip);
+    });
+    card.appendChild(chipsLine);
+
+    const countsLine = document.createElement('div');
+    countsLine.className = 'counts';
+    countsLine.textContent = `Proc. ${p.counts.processes} • Bind. ${p.counts.bindings}`;
+    card.appendChild(countsLine);
+
+    const cardDetails = document.createElement('div');
+    cardDetails.className = 'card-details hidden';
+    cardDetails.setAttribute('aria-hidden', 'true');
+    cardDetails.appendChild(renderPortDetails(p));
+    card.appendChild(cardDetails);
+
+    const toggleCard = () => toggleRow(card, cardDetails);
+    card.addEventListener('click', toggleCard);
+    card.addEventListener('keydown', e => { if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggleCard(); } });
+
+    cards.appendChild(card);
   });
 }
 
@@ -568,7 +640,7 @@ function initPortsUI(){
     t = setTimeout(() => { portSearch = e.target.value.toLowerCase(); applyPortFilters(); }, 250);
   });
 
-  document.querySelectorAll('#portsTable th[data-sort]').forEach(th => {
+  document.querySelectorAll('.ports-header [data-sort]').forEach(th => {
     th.addEventListener('click', () => {
       const key = th.dataset.sort;
       if (sortKey === key) sortDir *= -1; else { sortKey = key; sortDir = 1; }

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -912,13 +912,16 @@ h1 {
     .ports-filters { display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:0.5rem; }
     .ports-actions { display:flex; gap:0.5rem; align-items:center; margin-bottom:0.5rem; }
     #portSearch { flex:1; min-width:180px; }
-    .ports-table { width:100%; border-collapse:collapse; font-size:0.9rem; }
-    .ports-table th, .ports-table td { padding:0.3rem 0.4rem; border-bottom:1px solid var(--card-border); }
-    .ports-table th { position:sticky; top:0; background:var(--bg); cursor:pointer; }
-    .ports-table tbody tr:nth-child(even) { background:rgba(255,255,255,0.03); }
-    .ports-table tr.port-row { cursor:pointer; }
-    .ports-table td .badge { margin-right:0.2rem; }
-    .details-row.hidden { display:none; }
+    .ports-table { width:100%; font-size:0.9rem; }
+    .ports-header { position:sticky; top:0; background:var(--bg); box-shadow:0 1px 2px rgba(0,0,0,0.1); }
+    .ports-row { display:grid; grid-template-columns:110px 1.2fr 0.9fr 1.2fr 100px 110px 110px; gap:12px; align-items:center; padding:0.3rem 0.4rem; border-bottom:1px solid var(--card-border); cursor:pointer; }
+    .ports-row > * { min-width:0; }
+    .ports-body .ports-row:nth-child(even) { background:rgba(255,255,255,0.03); }
+    .truncate { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    .wrap { white-space:normal; word-break:break-word; overflow-wrap:anywhere; }
+    .chips { display:flex; flex-wrap:wrap; gap:4px; }
+    .col-processus, .col-bindings { }
+    .row-details.hidden { display:none; }
     .bindings-table { width:100%; border-collapse:collapse; margin-top:0.5rem; }
     .bindings-table th, .bindings-table td { padding:0.2rem 0.3rem; border-bottom:1px solid var(--card-border); font-size:0.85rem; }
     .bindings-table tbody tr:nth-child(even) { background:rgba(255,255,255,0.03); }
@@ -928,6 +931,37 @@ h1 {
     .badge.risk-low { background:var(--chip-bg); color:var(--text); }
     .iface { color:var(--text-muted); }
     .filter-chip .count { margin-left:0.25rem; opacity:0.7; }
+
+    .ports-cards { display:none; }
+    .port-card { border:1px solid var(--card-border); border-radius:12px; padding:12px; display:grid; gap:8px; }
+    .port-card .title { display:flex; justify-content:space-between; font-weight:600; }
+    .counts { font-size:0.85rem; }
+    .card-details.hidden { display:none; }
+
+    .chip { padding:2px 8px; border-radius:999px; font-size:12px; opacity:.9; }
+    .chip-public { background:#0e7490; color:#e0f2fe; }
+    .chip-docker { background:#1d4ed8; color:#dbeafe; }
+    .chip-localhost { background:#374151; color:#e5e7eb; }
+
+    .badge-admin { background:#2d3748; color:#e2e8f0; }
+    .badge-web { background:#1f2937; color:#e5e7eb; }
+    .badge-infra { background:#4b5563; color:#e5e7eb; }
+    .badge-fileshare { background:#374151; color:#e5e7eb; }
+    .badge-db { background:#1e40af; color:#e0e7ff; }
+    .badge-system { background:#065f46; color:#d1fae5; }
+    .badge-unknown { background:#6b7280; color:#f9fafb; }
+    .badge-other { background:#6b7280; color:#f9fafb; }
+
+    @media (max-width:1023px){
+      .col-processus, .col-bindings { display:none; }
+      .ports-row { grid-template-columns:100px 1.3fr 1fr 1fr 120px; }
+    }
+
+    @media (max-width:767px){
+      .ports-table { display:none; }
+      .ports-cards { display:flex; flex-direction:column; gap:12px; }
+      .bindings-table { display:block; overflow-x:auto; }
+    }
 
     .load-container {
       display: flex;


### PR DESCRIPTION
## Summary
- redesign open ports screen with grid-based header and rows
- add mobile card view with chips and risk badges
- introduce helpers for port formatting and badge mapping

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68aff83a615c832d9ec44b228820e6dc