### PR TITLE
Ensure disk cards use generic card styling

### DIFF
--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -1310,7 +1310,7 @@ function renderDisks(disks){
     const usedStr = disk.used || '';
     const freeStr = disk.available || '';
     const card = document.createElement('div');
-    card.className = 'disk-card';
+    card.className = 'card disk-card';
     card.tabIndex = 0;
     const aria = `Disque ${disk.mountpoint} : ${pctDisplay}% utilisés, ${usedStr} utilisés, ${freeStr} libres, total ${totalStr}`;
     card.innerHTML = `

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1253,7 +1253,7 @@ h1 {
     .chip.free { background: #4caf50; color: #fff; }
     .disk-grid { display:grid; gap:var(--gap-3); grid-template-columns:1fr; }
     @media (min-width:600px) { .disk-grid { grid-template-columns:repeat(2,1fr); } }
-    .disk-card { background:var(--block-bg); border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.2); padding:var(--gap-3); text-align:center; position:relative; }
+    .disk-card { padding:var(--gap-3); text-align:center; position:relative; }
     .disk-donut { width:120px; height:120px; margin:0 auto; display:block; }
     .disk-donut .donut-bg { fill:none; stroke:var(--bar-bg); stroke-width:3; }
     .disk-donut .donut-ring { fill:none; stroke-width:3; stroke-linecap:round; transform:rotate(-90deg); transform-origin:50% 50%; transition:stroke-dasharray .6s ease, stroke-width .2s ease; pointer-events:stroke; }


### PR DESCRIPTION
## Summary
- Use the generic `card` class for disk cards
- Streamline `.disk-card` CSS to inherit base card styles

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0084f85c0832d817d808d34b52155