### PR TITLE
Refactor state into Docker and Service stores

### DIFF
--- a/audits/scripts/modules/services.js
+++ b/audits/scripts/modules/services.js
@@ -1,8 +1,8 @@
-import { setServicesData } from './services/data.js';
+import { ServiceStore } from './services/data.js';
 import { initServicesUI, renderServicesList } from './services/ui.js';
 
 export function renderServices(names) {
   initServicesUI();
-  setServicesData(names);
+  ServiceStore.setData(names);
   renderServicesList();
 }

--- a/audits/scripts/modules/services/data.js
+++ b/audits/scripts/modules/services/data.js
@@ -29,69 +29,68 @@ export const SERVICE_PATTERNS = [
   { regex: /thermald/i, icon: '🌡️', category: 'Système' },
 ];
 
-export let servicesData = [];
-export let filteredServices = [];
-export let activeServiceCats = new Set(SERVICE_CATEGORIES);
-export let serviceSearch = '';
-export let serviceSort = 'az';
-
-export function getServiceMeta(name) {
+function getServiceMeta(name) {
   for (const p of SERVICE_PATTERNS) {
     if (p.regex.test(name)) return p;
   }
   return { icon: '⬜', category: 'Autre' };
 }
 
-export function setServicesData(names) {
-  servicesData = (names || []).map((n) => {
-    const meta = getServiceMeta(n);
-    return {
-      name: n,
-      icon: meta.icon,
-      category: meta.category,
-      desc: 'Service systemd',
-    };
-  });
-  return applyServiceFilters();
-}
-
-export function applyServiceFilters() {
-  filteredServices = servicesData.filter(
-    (s) =>
-      activeServiceCats.has(s.category) &&
-      s.name.toLowerCase().includes(serviceSearch),
-  );
-  if (serviceSort === 'az')
-    filteredServices.sort((a, b) => a.name.localeCompare(b.name));
-  else if (serviceSort === 'za')
-    filteredServices.sort((a, b) => b.name.localeCompare(a.name));
-  else if (serviceSort === 'cat')
-    filteredServices.sort(
-      (a, b) =>
-        a.category.localeCompare(b.category) || a.name.localeCompare(b.name),
+export const ServiceStore = {
+  data: [],
+  filtered: [],
+  activeCats: new Set(SERVICE_CATEGORIES),
+  search: '',
+  sort: 'az',
+  setData(names) {
+    this.data = (names || []).map((n) => {
+      const meta = getServiceMeta(n);
+      return {
+        name: n,
+        icon: meta.icon,
+        category: meta.category,
+        desc: 'Service systemd',
+      };
+    });
+    return this.applyFilters();
+  },
+  applyFilters() {
+    this.filtered = this.data.filter(
+      (s) =>
+        this.activeCats.has(s.category) &&
+        s.name.toLowerCase().includes(this.search),
     );
-  return filteredServices;
-}
-
-export function updateSearch(value) {
-  serviceSearch = value.toLowerCase();
-  return applyServiceFilters();
-}
-
-export function updateSort(value) {
-  serviceSort = value;
-  return applyServiceFilters();
-}
-
-export function toggleCategory(cat) {
-  if (activeServiceCats.has(cat)) activeServiceCats.delete(cat);
-  else activeServiceCats.add(cat);
-  return applyServiceFilters();
-}
-
-export function resetFilters() {
-  serviceSearch = '';
-  serviceSort = 'az';
-  activeServiceCats = new Set(SERVICE_CATEGORIES);
-  return applyServiceFilters();
-}
+    if (this.sort === 'az')
+      this.filtered.sort((a, b) => a.name.localeCompare(b.name));
+    else if (this.sort === 'za')
+      this.filtered.sort((a, b) => b.name.localeCompare(a.name));
+    else if (this.sort === 'cat')
+      this.filtered.sort(
+        (a, b) =>
+          a.category.localeCompare(b.category) || a.name.localeCompare(b.name),
+      );
+    return this.filtered;
+  },
+  updateSearch(value) {
+    this.search = value.toLowerCase();
+    return this.applyFilters();
+  },
+  updateSort(value) {
+    this.sort = value;
+    return this.applyFilters();
+  },
+  toggleCategory(cat) {
+    if (this.activeCats.has(cat)) this.activeCats.delete(cat);
+    else this.activeCats.add(cat);
+    return this.applyFilters();
+  },
+  resetFilters() {
+    this.search = '';
+    this.sort = 'az';
+    this.activeCats = new Set(SERVICE_CATEGORIES);
+    return this.applyFilters();
+  },
+  getFiltered() {
+    return this.filtered;
+  },
+};

--- a/audits/scripts/modules/services/ui.js
+++ b/audits/scripts/modules/services/ui.js
@@ -1,11 +1,4 @@
-import {
-  SERVICE_CATEGORIES,
-  filteredServices,
-  updateSearch,
-  updateSort,
-  toggleCategory,
-  resetFilters,
-} from './data.js';
+import { SERVICE_CATEGORIES, ServiceStore } from './data.js';
 
 let servicesInit = false;
 let servicesList;
@@ -39,16 +32,17 @@ function handleServicesListKeydown(e) {
 }
 
 export function renderServicesList() {
+  const list = ServiceStore.getFiltered();
   servicesList.textContent = '';
   const countSpan = document.getElementById('servicesCount');
-  if (filteredServices.length === 0) {
+  if (list.length === 0) {
     countSpan.textContent = '0 service';
     document.getElementById('servicesEmpty').classList.remove('hidden');
     return;
   }
   document.getElementById('servicesEmpty').classList.add('hidden');
   const frag = document.createDocumentFragment();
-  filteredServices.forEach((s) => {
+  list.forEach((s) => {
     const item = document.createElement('div');
     item.className = 'service-item';
     item.tabIndex = 0;
@@ -109,7 +103,7 @@ export function renderServicesList() {
     frag.appendChild(item);
   });
   servicesList.appendChild(frag);
-  countSpan.textContent = `${filteredServices.length} service${filteredServices.length > 1 ? 's' : ''}`;
+  countSpan.textContent = `${list.length} service${list.length > 1 ? 's' : ''}`;
 }
 
 export function initServicesUI() {
@@ -125,22 +119,22 @@ export function initServicesUI() {
     chip.textContent = cat;
     chip.dataset.cat = cat;
     chip.addEventListener('click', () => {
-      toggleCategory(cat);
+      ServiceStore.toggleCategory(cat);
       chip.classList.toggle('active');
       renderServicesList();
     });
     filtersDiv.appendChild(chip);
   });
   searchInput.addEventListener('input', (e) => {
-    updateSearch(e.target.value);
+    ServiceStore.updateSearch(e.target.value);
     renderServicesList();
   });
   sortSelect.addEventListener('change', (e) => {
-    updateSort(e.target.value);
+    ServiceStore.updateSort(e.target.value);
     renderServicesList();
   });
   document.getElementById('resetFilters').addEventListener('click', () => {
-    resetFilters();
+    ServiceStore.resetFilters();
     searchInput.value = '';
     sortSelect.value = 'az';
     document


### PR DESCRIPTION
## Summary
- Encapsulate Docker data and filtering in `DockerStore`
- Group service-related state and helpers in new `ServiceStore`
- Update rendering and UI modules to use the new stores

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b01f363868832da92f138887eb4d38