### PR TITLE
Refactor Docker container card rendering

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -204,6 +204,28 @@
       <option value="name" selected>Nom</option>
     </select>
   </div>
+  <template id="tpl-docker-card">
+    <div class="docker-card" tabindex="0">
+      <div class="docker-head">
+        <div class="docker-title">
+          <span class="docker-icon"></span>
+          <span class="docker-name"></span>
+        </div>
+        <span class="status-badge"></span>
+      </div>
+      <div class="docker-uptime"></div>
+      <div class="docker-bars">
+        <div class="bar-outer cpu">
+          <div class="fill"></div>
+          <span class="bar-value"></span>
+        </div>
+        <div class="bar-outer ram">
+          <div class="fill"></div>
+          <span class="bar-value"></span>
+        </div>
+      </div>
+    </div>
+  </template>
   <div id="dockerGrid" class="docker-grid"></div>
   <div id="dockerEmpty" class="empty hidden">Aucun conteneur actif</div>
   </main>

--- a/audits/scripts/modules/docker.js
+++ b/audits/scripts/modules/docker.js
@@ -130,89 +130,57 @@ function renderDockerList() {
     return;
   }
   document.getElementById('dockerEmpty').classList.add('hidden');
+  const template = document.getElementById('tpl-docker-card');
   const frag = document.createDocumentFragment();
   const updates = [];
   list.forEach((c) => {
-    const card = document.createElement('div');
-    card.setAttribute('class', 'docker-card');
-    card.setAttribute('tabindex', '0');
+    const node = template.content.cloneNode(true);
+    const card = node.querySelector('.docker-card');
+    const iconSpan = node.querySelector('.docker-icon');
+    const nameSpan = node.querySelector('.docker-name');
+    const badge = node.querySelector('.status-badge');
+    const uptimeDiv = node.querySelector('.docker-uptime');
+    const cpuOuter = node.querySelector('.bar-outer.cpu');
+    const cpuFill = cpuOuter.querySelector('.fill');
+    const cpuValue = cpuOuter.querySelector('.bar-value');
+    const ramOuter = node.querySelector('.bar-outer.ram');
+    const ramFill = ramOuter.querySelector('.fill');
+    const ramValue = ramOuter.querySelector('.bar-value');
+
     const health = c.health ?? '';
     card.setAttribute(
       'title',
       `CPU ${c.cpu}% — RAM ${c.mem}%${health ? ` — Status ${health}` : ''}`,
     );
-    const cpuColor = colorClassCpu(c.cpu);
-    const ramColor = colorClassRam(c.mem);
-    const icon = iconFor(c.name);
-    const memDisplay = c.memText || `${c.mem}%`;
 
-    const head = document.createElement('div');
-    head.setAttribute('class', 'docker-head');
-
-    const title = document.createElement('div');
-    title.setAttribute('class', 'docker-title');
-
-    const iconSpan = document.createElement('span');
-    iconSpan.setAttribute('class', 'docker-icon');
-    iconSpan.textContent = icon;
-
-    const nameSpan = document.createElement('span');
-    nameSpan.setAttribute('class', 'docker-name');
+    iconSpan.textContent = iconFor(c.name);
     nameSpan.textContent = c.name;
-
-    title.appendChild(iconSpan);
-    title.appendChild(nameSpan);
-    head.appendChild(title);
-
-    if (health) {
-      const badge = document.createElement('span');
-      badge.setAttribute('class', `status-badge status-${health}`);
-      badge.textContent = health;
-      head.appendChild(badge);
-    }
-
-    const uptimeDiv = document.createElement('div');
-    uptimeDiv.setAttribute('class', 'docker-uptime');
     uptimeDiv.textContent = c.uptime;
 
-    const bars = document.createElement('div');
-    bars.setAttribute('class', 'docker-bars');
+    if (health) {
+      badge.textContent = health;
+      badge.classList.add(`status-${health}`);
+    } else {
+      badge.remove();
+    }
 
-    const cpuOuter = document.createElement('div');
-    cpuOuter.setAttribute('class', 'bar-outer cpu');
-    const cpuFill = document.createElement('div');
-    cpuFill.classList.add('fill', cpuColor);
-    const cpuValue = document.createElement('span');
-    cpuValue.setAttribute('class', 'bar-value');
+    const cpuColor = colorClassCpu(c.cpu);
+    const ramColor = colorClassRam(c.mem);
+    const memDisplay = c.memText || `${c.mem}%`;
+
+    cpuFill.classList.add(cpuColor);
     cpuValue.textContent = `${c.cpu}%`;
-    cpuOuter.appendChild(cpuFill);
-    cpuOuter.appendChild(cpuValue);
-
-    const ramOuter = document.createElement('div');
-    ramOuter.setAttribute('class', 'bar-outer ram');
-    const ramFill = document.createElement('div');
-    ramFill.classList.add('fill', ramColor);
-    const ramValue = document.createElement('span');
-    ramValue.setAttribute('class', 'bar-value');
+    ramFill.classList.add(ramColor);
     ramValue.textContent = memDisplay;
-    ramOuter.appendChild(ramFill);
-    ramOuter.appendChild(ramValue);
 
-    bars.appendChild(cpuOuter);
-    bars.appendChild(ramOuter);
-
-    card.appendChild(head);
-    card.appendChild(uptimeDiv);
-    card.appendChild(bars);
-
-    frag.appendChild(card);
-    updates.push({ fills: [cpuFill, ramFill], cpu: c.cpu, mem: c.mem });
+    frag.appendChild(node);
+    updates.push({ cpuFill, ramFill, cpu: c.cpu, mem: c.mem });
   });
   grid.appendChild(frag);
   requestAnimationFrame(() => {
-    updates.forEach(({ fills, cpu, mem }) => {
-      fills[0].style.width = cpu + '%';
-      fills[1].style.width = mem + '%';
+    updates.forEach(({ cpuFill, ramFill, cpu, mem }) => {
+      cpuFill.style.width = cpu + '%';
+      ramFill.style.width = mem + '%';
     });
   });
 }


### PR DESCRIPTION
## Summary
- add reusable HTML template for Docker container cards
- render Docker container list by cloning template and populating fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b022f229e8832db7fedfd172fe7d72