### PR TITLE
refactor: render services from template

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -172,6 +172,30 @@
       <div class="service-skeleton skeleton"></div>
       <div class="service-skeleton skeleton"></div>
     </div>
+    <template id="tpl-service-item">
+      <div class="service-item" tabindex="0" aria-expanded="false">
+        <div class="service-main">
+          <span class="service-icon"></span>
+          <span class="service-name"></span>
+          <span class="service-badge"></span>
+        </div>
+        <div class="service-details">
+          <div>
+            <strong>Nom de l’unité :</strong>
+            <code class="service-unit"></code>
+            <button class="copy-btn small" title="Copier le nom">📋</button>
+          </div>
+          <div>
+            <strong>Type :</strong>
+            service
+          </div>
+          <div>
+            <strong>Description :</strong>
+            <span class="service-desc"></span>
+          </div>
+        </div>
+      </div>
+    </template>
     <div id="servicesEmpty" class="empty hidden">
       Aucun service ne correspond au filtre.
       <button id="resetFilters" class="btn">Réinitialiser les filtres</button>

--- a/audits/scripts/modules/services/ui.js
+++ b/audits/scripts/modules/services/ui.js
@@ -42,64 +42,21 @@ export function renderServicesList() {
   }
   document.getElementById('servicesEmpty').classList.add('hidden');
   const frag = document.createDocumentFragment();
+  const tpl = document.getElementById('tpl-service-item');
   list.forEach((s) => {
-    const item = document.createElement('div');
-    item.className = 'service-item';
-    item.tabIndex = 0;
+    const item = tpl.content.firstElementChild.cloneNode(true);
     item.title = s.desc;
-    item.setAttribute('aria-expanded', 'false');
-
-    const main = document.createElement('div');
-    main.className = 'service-main';
-
-    const iconSpan = document.createElement('span');
-    iconSpan.className = 'service-icon';
-    iconSpan.textContent = s.icon;
-    main.appendChild(iconSpan);
-
-    const nameSpan = document.createElement('span');
-    nameSpan.className = 'service-name';
-    nameSpan.textContent = s.name;
-    main.appendChild(nameSpan);
-
-    const badgeSpan = document.createElement('span');
-    badgeSpan.className =
-      'service-badge cat-' + s.category.toLowerCase().replace(/[\s/]+/g, '-');
-    badgeSpan.textContent = s.category;
-    main.appendChild(badgeSpan);
-
-    item.appendChild(main);
-
-    const details = document.createElement('div');
-    details.className = 'service-details';
-
-    const nameDiv = document.createElement('div');
-    const strongName = document.createElement('strong');
-    strongName.textContent = 'Nom de l’unité :';
-    const code = document.createElement('code');
-    code.textContent = s.name;
-    const copyBtn = document.createElement('button');
-    copyBtn.className = 'copy-btn small';
-    copyBtn.title = 'Copier le nom';
-    copyBtn.textContent = '📋';
+    item.querySelector('.service-icon').textContent = s.icon;
+    item.querySelector('.service-name').textContent = s.name;
+    const badge = item.querySelector('.service-badge');
+    badge.textContent = s.category;
+    badge.classList.add(
+      'cat-' + s.category.toLowerCase().replace(/[\s/]+/g, '-')
+    );
+    item.querySelector('.service-unit').textContent = s.name;
+    const copyBtn = item.querySelector('.copy-btn');
     copyBtn.dataset.name = s.name;
-    nameDiv.append(strongName, ' ', code, ' ', copyBtn);
-    details.appendChild(nameDiv);
-
-    const typeDiv = document.createElement('div');
-    const strongType = document.createElement('strong');
-    strongType.textContent = 'Type :';
-    typeDiv.append(strongType, ' service');
-    details.appendChild(typeDiv);
-
-    const descDiv = document.createElement('div');
-    const strongDesc = document.createElement('strong');
-    strongDesc.textContent = 'Description :';
-    descDiv.append(strongDesc, ' ', s.desc);
-    details.appendChild(descDiv);
-
-    item.appendChild(details);
-
+    item.querySelector('.service-desc').textContent = s.desc;
     frag.appendChild(item);
   });
   servicesList.appendChild(frag);


### PR DESCRIPTION
## Summary
- add HTML template for service items
- render services by cloning template content instead of manual DOM creation

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b024557644832d88060705106743b6