### PR TITLE
refactor: extract generic list store

### DIFF
--- a/audits/scripts/modules/docker.js
+++ b/audits/scripts/modules/docker.js
@@ -1,46 +1,19 @@
 import { iconFor, colorClassCpu, colorClassRam } from './ui.js';
+import { createListStore } from './store.js';
 
-export const DockerStore = {
-  data: [],
-  filtered: [],
-  filters: new Set(['healthy', 'unhealthy', 'running', 'exited']),
-  search: '',
+export const DockerStore = createListStore({
   sort: 'name',
-  setData(arr) {
-    this.data = arr;
-    return this.applyFilters();
+  filters: new Set(['healthy', 'unhealthy', 'running', 'exited']),
+  filterFunc(c) {
+    const status = c.health === 'starting' ? 'running' : c.health || c.state;
+    return this.filters.has(status) && c.name.toLowerCase().includes(this.search);
   },
-  setSearch(val) {
-    this.search = val.toLowerCase();
-    return this.applyFilters();
+  sortFunc(list) {
+    if (this.sort === 'cpu') list.sort((a, b) => b.cpu - a.cpu);
+    else if (this.sort === 'ram') list.sort((a, b) => b.mem - a.mem);
+    else list.sort((a, b) => a.name.localeCompare(b.name));
   },
-  setSort(val) {
-    this.sort = val;
-    return this.applyFilters();
-  },
-  toggleFilter(f) {
-    if (this.filters.has(f)) this.filters.delete(f);
-    else this.filters.add(f);
-    return this.applyFilters();
-  },
-  applyFilters() {
-    this.filtered = this.data.filter((c) => {
-      const status = c.health === 'starting' ? 'running' : c.health || c.state;
-      return (
-        this.filters.has(status) &&
-        c.name.toLowerCase().includes(this.search)
-      );
-    });
-    if (this.sort === 'cpu') this.filtered.sort((a, b) => b.cpu - a.cpu);
-    else if (this.sort === 'ram') this.filtered.sort((a, b) => b.mem - a.mem);
-    else this.filtered.sort((a, b) => a.name.localeCompare(b.name));
-    return this.filtered;
-  },
-  getFiltered() {
-    return this.filtered;
-  },
-};
-
+});
 let dockerInit = false;
 
 function formatBytes(b) {

--- a/audits/scripts/modules/services.js
+++ b/audits/scripts/modules/services.js
@@ -1,4 +1,4 @@
-import { ServiceStore } from './services/data.js';
+import ServiceStore from './services/data.js';
 import { initServicesUI, renderServicesList } from './services/ui.js';
 
 export function renderServices(names) {

--- a/audits/scripts/modules/services/ui.js
+++ b/audits/scripts/modules/services/ui.js
@@ -1,4 +1,4 @@
-import { SERVICE_CATEGORIES, ServiceStore } from './data.js';
+import ServiceStore, { SERVICE_CATEGORIES } from './data.js';
 
 let servicesInit = false;
 let servicesList;
@@ -83,11 +83,11 @@ export function initServicesUI() {
     filtersDiv.appendChild(chip);
   });
   searchInput.addEventListener('input', (e) => {
-    ServiceStore.updateSearch(e.target.value);
+    ServiceStore.setSearch(e.target.value);
     renderServicesList();
   });
   sortSelect.addEventListener('change', (e) => {
-    ServiceStore.updateSort(e.target.value);
+    ServiceStore.setSort(e.target.value);
     renderServicesList();
   });
   document.getElementById('resetFilters').addEventListener('click', () => {
@@ -103,3 +103,4 @@ export function initServicesUI() {
   servicesList.addEventListener('click', handleServicesListClick);
   servicesList.addEventListener('keydown', handleServicesListKeydown);
 }
+

--- a/audits/scripts/modules/store.js
+++ b/audits/scripts/modules/store.js
@@ -1,0 +1,47 @@
+export function createListStore({
+  data = [],
+  filtered = [],
+  search = '',
+  sort = '',
+  filters = new Set(),
+  filterFunc = () => true,
+  sortFunc = () => {},
+  resetFunc = null,
+} = {}) {
+  return {
+    data,
+    filtered,
+    search,
+    sort,
+    filters,
+    setData(arr) {
+      this.data = arr || [];
+      return this.applyFilters();
+    },
+    setSearch(value) {
+      this.search = value.toLowerCase();
+      return this.applyFilters();
+    },
+    setSort(value) {
+      this.sort = value;
+      return this.applyFilters();
+    },
+    toggleFilter(val) {
+      if (this.filters.has(val)) this.filters.delete(val);
+      else this.filters.add(val);
+      return this.applyFilters();
+    },
+    applyFilters() {
+      this.filtered = this.data.filter((item) => filterFunc.call(this, item));
+      sortFunc.call(this, this.filtered);
+      return this.filtered;
+    },
+    resetFilters() {
+      if (typeof resetFunc === 'function') resetFunc.call(this);
+      return this.applyFilters();
+    },
+    getFiltered() {
+      return this.filtered;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- factor out reusable createListStore for filtering, searching and sorting lists
- refactor ServiceStore and DockerStore to use the generic list store
- update modules to import and interact with the new stores

## Testing
- `npm run lint`
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b025d3487c832db544b81ba7da288a