### PR TITLE
refactor: extract service config

### DIFF
--- a/audits/scripts/modules/services/config.js
+++ b/audits/scripts/modules/services/config.js
@@ -1,0 +1,30 @@
+export const SERVICE_CATEGORIES = [
+  'Système',
+  'Réseau',
+  'Stockage/Partages',
+  'Conteneurs',
+  'Sécurité',
+  'Journalisation',
+  'Mises à jour',
+  'Autre',
+];
+
+export const SERVICE_PATTERNS = [
+  { regex: /docker|containerd/i, icon: '🐳', category: 'Conteneurs' },
+  { regex: /ssh/i, icon: '🔐', category: 'Sécurité' },
+  { regex: /cron/i, icon: '⏱️', category: 'Système' },
+  { regex: /dbus/i, icon: '🔌', category: 'Système' },
+  { regex: /ntp|ntpsec|timesync/i, icon: '🕒', category: 'Réseau' },
+  { regex: /rpcbind/i, icon: '🧭', category: 'Réseau' },
+  { regex: /rpc|nfs/i, icon: '📡', category: 'Réseau' },
+  { regex: /smb|smbd|nmbd|cifs/i, icon: '🗂️', category: 'Stockage/Partages' },
+  {
+    regex: /systemd-(journald|logind|networkd|resolved|udevd)/i,
+    icon: '⚙️',
+    category: 'Système',
+  },
+  { regex: /rsyslog/i, icon: '📝', category: 'Journalisation' },
+  { regex: /bluetooth/i, icon: '📶', category: 'Réseau' },
+  { regex: /unattended-upgrades/i, icon: '🔄', category: 'Mises à jour' },
+  { regex: /thermald/i, icon: '🌡️', category: 'Système' },
+];

--- a/audits/scripts/modules/services/data.js
+++ b/audits/scripts/modules/services/data.js
@@ -1,35 +1,6 @@
 import { createListStore } from '../store.js';
-
-export const SERVICE_CATEGORIES = [
-  'Système',
-  'Réseau',
-  'Stockage/Partages',
-  'Conteneurs',
-  'Sécurité',
-  'Journalisation',
-  'Mises à jour',
-  'Autre',
-];
-
-export const SERVICE_PATTERNS = [
-  { regex: /docker|containerd/i, icon: '🐳', category: 'Conteneurs' },
-  { regex: /ssh/i, icon: '🔐', category: 'Sécurité' },
-  { regex: /cron/i, icon: '⏱️', category: 'Système' },
-  { regex: /dbus/i, icon: '🔌', category: 'Système' },
-  { regex: /ntp|ntpsec|timesync/i, icon: '🕒', category: 'Réseau' },
-  { regex: /rpcbind/i, icon: '🧭', category: 'Réseau' },
-  { regex: /rpc|nfs/i, icon: '📡', category: 'Réseau' },
-  { regex: /smb|smbd|nmbd|cifs/i, icon: '🗂️', category: 'Stockage/Partages' },
-  {
-    regex: /systemd-(journald|logind|networkd|resolved|udevd)/i,
-    icon: '⚙️',
-    category: 'Système',
-  },
-  { regex: /rsyslog/i, icon: '📝', category: 'Journalisation' },
-  { regex: /bluetooth/i, icon: '📶', category: 'Réseau' },
-  { regex: /unattended-upgrades/i, icon: '🔄', category: 'Mises à jour' },
-  { regex: /thermald/i, icon: '🌡️', category: 'Système' },
-];
+import { SERVICE_CATEGORIES, SERVICE_PATTERNS } from './config.js';
+export { SERVICE_CATEGORIES, SERVICE_PATTERNS };
 
 function getServiceMeta(name) {
   for (const p of SERVICE_PATTERNS) {


### PR DESCRIPTION
## Summary
- move service categories and patterns to new services/config.js
- use shared configuration in services/data.js

## Testing
- `npm run build`
- `./tests/run.sh` *(fails: Commande requise manquante : mpstat)*

------
https://chatgpt.com/codex/tasks/task_e_68b0282e7748832d915432fed18d168b