### PR TITLE
Respect system color scheme for initial theme

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -266,8 +266,19 @@
       localStorage.setItem("theme", next);
       applyTheme(next);
     });
-    applyTheme(localStorage.getItem("theme") || "dark");
+    const storedTheme = localStorage.getItem("theme");
+    if (storedTheme) {
+      applyTheme(storedTheme);
+    } else {
+      const mql = window.matchMedia("(prefers-color-scheme: light)");
+      applyTheme(mql.matches ? "light" : "dark");
+      mql.addEventListener("change", e => {
+        if (!localStorage.getItem("theme")) {
+          applyTheme(e.matches ? "light" : "dark");
+        }
+      });
+    }
   </script>
 
 </body>
-</html>
+  </html>


### PR DESCRIPTION
## Summary
- Choose initial theme based on stored preference or system `prefers-color-scheme`
- React to system color scheme changes when no theme preference is saved

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b02cee8e80832db15f4de4779b2fd6