### PR TITLE
docs: update to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2025-09-30
+
+- Added automatic theme detection and dark/light mode support.
+- Refactored front-end modules and templates for services and Docker.
 - Removed open ports section from audit report generation and frontend viewer.
 
 ## [1.2.0] - 2025-08-27

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Audit Server
 
-**Version 1.2.0** – this repository reflects the state of the project at release v1.2.0. All work that occurred
-after this tag has been discarded.
+**Version 1.3.0** – this repository contains the latest updates, including automatic theme detection and
+front-end refactors.
 
 Audit Server generates periodic JSON reports describing the state of a host and exposes them through a static web
 viewer. The solution is composed of three parts:
@@ -10,6 +10,8 @@ viewer. The solution is composed of three parts:
   containers) and stores them as timestamped JSON files.
 * `audits/` – static HTML, CSS and JavaScript viewer that loads and renders those JSON files in a browser.
 * `docker-compose.yaml` and `nginx.conf` – optional container setup to serve the viewer with Nginx.
+
+The viewer automatically matches the system's light or dark theme.
 
 The front‑end code is written as ES modules and bundled with [esbuild](https://esbuild.github.io/). Development
 dependencies such as `esbuild`, `eslint` and `prettier` are listed in `package.json`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # 🚀 Deployment Guide
 
 This guide explains how to serve audit reports through Nginx running in Docker with Traefik. It applies to
-Audit Server version 1.2.0.
+Audit Server version 1.3.0.
 
 1. Generate audits (or schedule the script):
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # 🛠️ Installation Guide
 
-This guide explains how to set up Audit Server version 1.2.0 from scratch.
+This guide explains how to set up Audit Server version 1.3.0 from scratch.
 
 ## 1. Clone the repository
 

--- a/docs/REPORT_STRUCTURE.md
+++ b/docs/REPORT_STRUCTURE.md
@@ -1,7 +1,7 @@
 # 🧾 Audit Report Structure
 
 The `generate-audit-json.sh` script outputs a JSON file summarizing system metrics. This specification describes
-the format used in Audit Server version 1.2.0. The top-level object contains:
+the format used in Audit Server version 1.3.0. The top-level object contains:
 
 - `generated`: human-readable timestamp of report generation.
 - `hostname`: system hostname.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,7 @@
 # 📘 Audit Server Documentation
 
 This document provides extra details on how to use the audit script and serve the resulting reports. It applies to
-version 1.2.0 of the project. For installation instructions, see [INSTALLATION.md](INSTALLATION.md).
+version 1.3.0 of the project. For installation instructions, see [INSTALLATION.md](INSTALLATION.md).
 
 ## 📊 Generating reports
 


### PR DESCRIPTION
## Summary
- bump docs to v1.3.0 and note automatic theme detection
- refresh deployment, installation, usage, and report structure guides
- add 1.3.0 release notes to changelog

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b02e525c34832da366092d70c8fd77