### PR TITLE
docs: update for v1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.1] - 2025-10-15
+
+- Updated documentation for release v1.3.1.
+
 ## [1.3.0] - 2025-09-30
 
 - Added automatic theme detection and dark/light mode support.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audit Server
 
-**Version 1.3.0** – this repository contains the latest updates, including automatic theme detection and
+**Version 1.3.1** – this repository contains the latest updates, including automatic theme detection and
 front-end refactors.
 
 Audit Server generates periodic JSON reports describing the state of a host and exposes them through a static web

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,7 +1,7 @@
 # 🚀 Deployment Guide
 
 This guide explains how to serve audit reports through Nginx running in Docker with Traefik. It applies to
-Audit Server version 1.3.0.
+Audit Server version 1.3.1.
 
 1. Generate audits (or schedule the script):
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # 🛠️ Installation Guide
 
-This guide explains how to set up Audit Server version 1.3.0 from scratch.
+This guide explains how to set up Audit Server version 1.3.1 from scratch.
 
 ## 1. Clone the repository
 

--- a/docs/REPORT_STRUCTURE.md
+++ b/docs/REPORT_STRUCTURE.md
@@ -1,7 +1,7 @@
 # 🧾 Audit Report Structure
 
 The `generate-audit-json.sh` script outputs a JSON file summarizing system metrics. This specification describes
-the format used in Audit Server version 1.3.0. The top-level object contains:
+the format used in Audit Server version 1.3.1. The top-level object contains:
 
 - `generated`: human-readable timestamp of report generation.
 - `hostname`: system hostname.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,7 +1,7 @@
 # 📘 Audit Server Documentation
 
 This document provides extra details on how to use the audit script and serve the resulting reports. It applies to
-version 1.3.0 of the project. For installation instructions, see [INSTALLATION.md](INSTALLATION.md).
+version 1.3.1 of the project. For installation instructions, see [INSTALLATION.md](INSTALLATION.md).
 
 ## 📊 Generating reports
 


### PR DESCRIPTION
## Summary
- bump documentation references to version 1.3.1
- add changelog entry for v1.3.1

## Testing
- `./tests/run.sh` *(fails: Commande requise manquante : mpstat)*

------
https://chatgpt.com/codex/tasks/task_e_68b03d1a9538832da600d3da6c2af220