### PR TITLE
Simplify services list UI

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -156,10 +156,7 @@
         <span id="servicesCount">0 service</span>
       </div>
     </div>
-  <p class="services-help">Survolez un service pour voir sa description.</p>
   <div class="block-wrapper">
-    <input type="text" id="serviceSearch" placeholder="Filtrer un service… ex. ssh" />
-    <div id="categoryFilters" class="filter-chips"></div>
     <div class="services-toolbar">
       <select id="serviceSort">
         <option value="az">A→Z</option>
@@ -173,32 +170,16 @@
       <div class="service-skeleton skeleton"></div>
     </div>
     <template id="tpl-service-item">
-      <div class="service-item" tabindex="0" aria-expanded="false">
+      <div class="service-item">
         <div class="service-main">
           <span class="service-icon"></span>
           <span class="service-name"></span>
           <span class="service-badge"></span>
         </div>
-        <div class="service-details">
-          <div>
-            <strong>Nom de l’unité :</strong>
-            <code class="service-unit"></code>
-            <button class="copy-btn small" title="Copier le nom">📋</button>
-          </div>
-          <div>
-            <strong>Type :</strong>
-            service
-          </div>
-          <div>
-            <strong>Description :</strong>
-            <span class="service-desc"></span>
-          </div>
-        </div>
       </div>
     </template>
     <div id="servicesEmpty" class="empty hidden">
-      Aucun service ne correspond au filtre.
-      <button id="resetFilters" class="btn">Réinitialiser les filtres</button>
+      Aucun service actif.
     </div>
   </div>
 

--- a/audits/scripts/__tests__/ui.test.js
+++ b/audits/scripts/__tests__/ui.test.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { fireEvent } from '@testing-library/dom';
 import { jest } from '@jest/globals';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -13,14 +12,12 @@ describe('services UI', () => {
   let ServiceStore;
   let initServicesUI;
   let renderServicesList;
-  let SERVICE_CATEGORIES;
 
   beforeEach(async () => {
     jest.resetModules();
     document.body.innerHTML = bodyHtml;
     const dataModule = await import('../modules/services/data.js');
     ServiceStore = dataModule.default;
-    SERVICE_CATEGORIES = dataModule.SERVICE_CATEGORIES;
     const uiModule = await import('../modules/services/ui.js');
     initServicesUI = uiModule.initServicesUI;
     renderServicesList = uiModule.renderServicesList;
@@ -30,25 +27,12 @@ describe('services UI', () => {
     global.alert = jest.fn();
   });
 
-  test('initServicesUI creates chips and handles clicks', () => {
+  test('renderServicesList shows services without filters', () => {
     ServiceStore.setData(['sshd', 'cron']);
     initServicesUI();
     renderServicesList();
     const chips = document.querySelectorAll('#categoryFilters .filter-chip');
-    expect(chips.length).toBe(SERVICE_CATEGORIES.length);
-    const itemsBefore = document.querySelectorAll('#servicesList .service-item');
-    expect(itemsBefore.length).toBe(2);
-    const secChip = Array.from(chips).find((c) => c.textContent === 'Sécurité');
-    fireEvent.click(secChip);
-    expect(secChip.classList.contains('active')).toBe(false);
-    const itemsAfter = document.querySelectorAll('#servicesList .service-item');
-    expect(itemsAfter.length).toBe(1);
-  });
-
-  test('renderServicesList shows full list', () => {
-    ServiceStore.setData(['sshd', 'cron']);
-    initServicesUI();
-    renderServicesList();
+    expect(chips.length).toBe(0);
     const items = document.querySelectorAll('#servicesList .service-item');
     expect(items.length).toBe(2);
     expect(document.getElementById('servicesCount').textContent).toBe('2 services');
@@ -107,22 +91,3 @@ describe('setupCopy', () => {
   });
 });
 
-describe('toggleServiceItem', () => {
-  let toggleServiceItem;
-  beforeEach(async () => {
-    jest.resetModules();
-    ({ toggleServiceItem } = await import('../modules/services/ui.js'));
-  });
-
-  test('toggles aria-expanded and class', () => {
-    const item = document.createElement('div');
-    item.className = 'service-item';
-    item.setAttribute('aria-expanded', 'false');
-    toggleServiceItem(item);
-    expect(item.classList.contains('expanded')).toBe(true);
-    expect(item.getAttribute('aria-expanded')).toBe('true');
-    toggleServiceItem(item);
-    expect(item.classList.contains('expanded')).toBe(false);
-    expect(item.getAttribute('aria-expanded')).toBe('false');
-  });
-});

--- a/audits/scripts/modules/__tests__/services.test.js
+++ b/audits/scripts/modules/__tests__/services.test.js
@@ -15,13 +15,13 @@ describe('ServiceStore', () => {
     expect(other.category).toBe('Autre');
   });
 
-  it('filters by category', () => {
-    ServiceStore.setData(['sshd', 'cron']);
-    ServiceStore.toggleCategory('Sécurité');
-    const filtered = ServiceStore.getFiltered().map((s) => s.name);
-    expect(filtered).toEqual(['cron']);
-    ServiceStore.toggleCategory('Sécurité');
-    const again = ServiceStore.getFiltered().map((s) => s.name);
-    expect(again).toContain('sshd');
+  it('sorts services', () => {
+    ServiceStore.setData(['b.service', 'a.service']);
+    ServiceStore.setSort('az');
+    const az = ServiceStore.getFiltered().map((s) => s.name);
+    expect(az).toEqual(['a.service', 'b.service']);
+    ServiceStore.setSort('za');
+    const za = ServiceStore.getFiltered().map((s) => s.name);
+    expect(za).toEqual(['b.service', 'a.service']);
   });
 });

--- a/audits/scripts/modules/services/config.js
+++ b/audits/scripts/modules/services/config.js
@@ -1,14 +1,3 @@
-export const SERVICE_CATEGORIES = [
-  'Système',
-  'Réseau',
-  'Stockage/Partages',
-  'Conteneurs',
-  'Sécurité',
-  'Journalisation',
-  'Mises à jour',
-  'Autre',
-];
-
 export const SERVICE_PATTERNS = [
   { regex: /docker|containerd/i, icon: '🐳', category: 'Conteneurs' },
   { regex: /ssh/i, icon: '🔐', category: 'Sécurité' },

--- a/audits/scripts/modules/services/data.js
+++ b/audits/scripts/modules/services/data.js
@@ -1,6 +1,6 @@
 import { createListStore } from '../store.js';
-import { SERVICE_CATEGORIES, SERVICE_PATTERNS } from './config.js';
-export { SERVICE_CATEGORIES, SERVICE_PATTERNS };
+import { SERVICE_PATTERNS } from './config.js';
+export { SERVICE_PATTERNS };
 
 function getServiceMeta(name) {
   for (const p of SERVICE_PATTERNS) {
@@ -11,12 +11,8 @@ function getServiceMeta(name) {
 
 const ServiceStore = createListStore({
   sort: 'az',
-  search: '',
-  filterFunc(service) {
-    return (
-      this.activeCats.has(service.category) &&
-      service.name.toLowerCase().includes(this.search)
-    );
+  filterFunc() {
+    return true;
   },
   sortFunc(list) {
     if (this.sort === 'az') list.sort((a, b) => a.name.localeCompare(b.name));
@@ -28,13 +24,9 @@ const ServiceStore = createListStore({
       );
   },
   resetFunc() {
-    this.search = '';
     this.sort = 'az';
-    this.activeCats = new Set(SERVICE_CATEGORIES);
   },
 });
-
-ServiceStore.activeCats = new Set(SERVICE_CATEGORIES);
 
 ServiceStore.setData = function (names) {
   this.data = (names || []).map((n) => {
@@ -43,15 +35,8 @@ ServiceStore.setData = function (names) {
       name: n,
       icon: meta.icon,
       category: meta.category,
-      desc: 'Service systemd',
     };
   });
-  return this.applyFilters();
-};
-
-ServiceStore.toggleCategory = function (cat) {
-  if (this.activeCats.has(cat)) this.activeCats.delete(cat);
-  else this.activeCats.add(cat);
   return this.applyFilters();
 };
 

--- a/audits/scripts/modules/services/ui.js
+++ b/audits/scripts/modules/services/ui.js
@@ -1,35 +1,7 @@
-import ServiceStore, { SERVICE_CATEGORIES } from './data.js';
+import ServiceStore from './data.js';
 
 let servicesInit = false;
 let servicesList;
-
-export function toggleServiceItem(item) {
-  const expanded = item.classList.toggle('expanded');
-  item.setAttribute('aria-expanded', expanded);
-}
-
-function handleServicesListClick(e) {
-  const copyBtn = e.target.closest('.copy-btn');
-  if (copyBtn) {
-    e.stopPropagation();
-    navigator.clipboard
-      .writeText(copyBtn.dataset.name)
-      .then(() => alert('Copié dans le presse-papiers !'));
-    return;
-  }
-  const item = e.target.closest('.service-item');
-  if (item) toggleServiceItem(item);
-}
-
-function handleServicesListKeydown(e) {
-  if (e.key !== 'Enter' && e.key !== ' ') return;
-  if (e.target.closest('.copy-btn')) return;
-  const item = e.target.closest('.service-item');
-  if (item) {
-    e.preventDefault();
-    toggleServiceItem(item);
-  }
-}
 
 export function renderServicesList() {
   const list = ServiceStore.getFiltered();
@@ -45,7 +17,6 @@ export function renderServicesList() {
   const tpl = document.getElementById('tpl-service-item');
   list.forEach((s) => {
     const item = tpl.content.firstElementChild.cloneNode(true);
-    item.title = s.desc;
     item.querySelector('.service-icon').textContent = s.icon;
     item.querySelector('.service-name').textContent = s.name;
     const badge = item.querySelector('.service-badge');
@@ -53,10 +24,6 @@ export function renderServicesList() {
     badge.classList.add(
       'cat-' + s.category.toLowerCase().replace(/[\s/]+/g, '-')
     );
-    item.querySelector('.service-unit').textContent = s.name;
-    const copyBtn = item.querySelector('.copy-btn');
-    copyBtn.dataset.name = s.name;
-    item.querySelector('.service-desc').textContent = s.desc;
     frag.appendChild(item);
   });
   servicesList.appendChild(frag);
@@ -66,41 +33,11 @@ export function renderServicesList() {
 export function initServicesUI() {
   if (servicesInit) return;
   servicesInit = true;
-  const searchInput = document.getElementById('serviceSearch');
   const sortSelect = document.getElementById('serviceSort');
-  const filtersDiv = document.getElementById('categoryFilters');
   servicesList = document.getElementById('servicesList');
-  SERVICE_CATEGORIES.forEach((cat) => {
-    const chip = document.createElement('button');
-    chip.className = 'filter-chip active';
-    chip.textContent = cat;
-    chip.dataset.cat = cat;
-    chip.addEventListener('click', () => {
-      ServiceStore.toggleCategory(cat);
-      chip.classList.toggle('active');
-      renderServicesList();
-    });
-    filtersDiv.appendChild(chip);
-  });
-  searchInput.addEventListener('input', (e) => {
-    ServiceStore.setSearch(e.target.value);
-    renderServicesList();
-  });
   sortSelect.addEventListener('change', (e) => {
     ServiceStore.setSort(e.target.value);
     renderServicesList();
   });
-  document.getElementById('resetFilters').addEventListener('click', () => {
-    ServiceStore.resetFilters();
-    searchInput.value = '';
-    sortSelect.value = 'az';
-    document
-      .querySelectorAll('#categoryFilters .filter-chip')
-      .forEach((c) => c.classList.add('active'));
-    renderServicesList();
-  });
-
-  servicesList.addEventListener('click', handleServicesListClick);
-  servicesList.addEventListener('keydown', handleServicesListKeydown);
 }
 

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -996,10 +996,6 @@ canvas {
   width: 60px;
   height: 20px;
 }
-.filter-chip .count {
-  margin-left: 0.25rem;
-  opacity: 0.7;
-}
 .load-container {
   display: flex;
   flex-direction: column;
@@ -1131,36 +1127,6 @@ canvas {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
-}
-.services-help {
-  font-size: 0.9rem;
-  color: #bbb;
-  margin-top: -0.5rem;
-  margin-bottom: 0.5rem;
-}
-#serviceSearch {
-  width: 100%;
-  margin-bottom: 0.5rem;
-}
-.filter-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-.filter-chip {
-  background: var(--chip-bg);
-  color: var(--chip-text);
-  border: none;
-  border-radius: 9999px;
-  padding: 0.25rem 0.6rem;
-  cursor: pointer;
-  font-size: 0.85rem;
-  font-family: var(--font-mono);
-}
-.filter-chip.active {
-  background: var(--chip-active-bg);
-  color: var(--bg);
 }
 .services-toolbar {
   display: flex;
@@ -1597,12 +1563,6 @@ canvas {
   .services-toolbar {
     justify-content: flex-start;
   }
-  .filter-chips {
-    position: sticky;
-    top: 0;
-    background: var(--bg);
-    padding-top: 0.5rem;
-  }
   .cpu .card-head {
     flex-direction: column;
     align-items: flex-start;
@@ -1843,14 +1803,6 @@ main {
   font-size: 0.75rem;
   background: #555;
   font-family: var(--font-mono);
-}
-.service-details {
-  display: none;
-  margin-top: 0.5rem;
-  font-size: 0.85rem;
-}
-.service-item.expanded .service-details {
-  display: block;
 }
 
 /* audits/styles/components/docker-card.css */

--- a/audits/styles/components/service-item.css
+++ b/audits/styles/components/service-item.css
@@ -28,11 +28,3 @@
       background: #555;
       font-family: var(--font-mono);
     }
-    .service-details {
-      display: none;
-      margin-top: 0.5rem;
-      font-size: 0.85rem;
-    }
-    .service-item.expanded .service-details {
-      display: block;
-    }

--- a/audits/styles/layout.css
+++ b/audits/styles/layout.css
@@ -526,7 +526,6 @@ h1 {
     }
     .mem .badge[data-tip] { position: relative; }
     .mem .spark { width: 60px; height: 20px; }
-    .filter-chip .count { margin-left:0.25rem; opacity:0.7; }
 
     .load-container {
       display: flex;
@@ -603,36 +602,6 @@ h1 {
       align-items: center;
       gap: 0.5rem;
       font-size: 0.9rem;
-    }
-    .services-help {
-      font-size: 0.9rem;
-      color: #bbb;
-      margin-top: -0.5rem;
-      margin-bottom: 0.5rem;
-    }
-    #serviceSearch {
-      width: 100%;
-      margin-bottom: 0.5rem;
-    }
-    .filter-chips {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-bottom: 0.5rem;
-    }
-    .filter-chip {
-      background: var(--chip-bg);
-      color: var(--chip-text);
-      border: none;
-      border-radius: 9999px;
-      padding: 0.25rem 0.6rem;
-      cursor: pointer;
-      font-size: 0.85rem;
-      font-family: var(--font-mono);
-    }
-    .filter-chip.active {
-      background: var(--chip-active-bg);
-      color: var(--bg);
     }
     .services-toolbar {
       display: flex;
@@ -828,7 +797,6 @@ h1 {
     @media (max-width: 600px) {
       .services-grid { grid-template-columns: 1fr; }
       .services-toolbar { justify-content: flex-start; }
-      .filter-chips { position: sticky; top: 0; background: var(--bg); padding-top: 0.5rem; }
       .cpu .card-head { flex-direction:column; align-items:flex-start; justify-content:flex-start; gap:4px; }
       .cpu .summary { flex-direction:row; gap:4px; }
       .cpu .core-list { margin-top:var(--gap-2); gap:4px; }


### PR DESCRIPTION
## Summary
- streamline active services list to show only name and category
- drop expandable details, copy buttons, and service filtering controls
- update tests and styles to reflect simplified services view

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b06ff725c0832d8354d93abeadf4a1