### PR TITLE
Allow selecting active service cards

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -170,7 +170,7 @@
       <div class="service-skeleton skeleton"></div>
     </div>
     <template id="tpl-service-item">
-      <div class="service-item">
+      <div class="service-item" tabindex="0">
         <div class="service-main">
           <span class="service-icon"></span>
           <span class="service-name"></span>

--- a/audits/scripts/__tests__/ui.test.js
+++ b/audits/scripts/__tests__/ui.test.js
@@ -35,6 +35,7 @@ describe('services UI', () => {
     expect(chips.length).toBe(0);
     const items = document.querySelectorAll('#servicesList .service-item');
     expect(items.length).toBe(2);
+    items.forEach((item) => expect(item.tabIndex).toBe(0));
     expect(document.getElementById('servicesCount').textContent).toBe('2 services');
   });
 });

--- a/audits/scripts/viewer.js
+++ b/audits/scripts/viewer.js
@@ -222,6 +222,7 @@ function renderServicesList(){
   sortedServices.forEach(s => {
     const item = document.createElement('div');
     item.className = 'service-item';
+    item.tabIndex = 0;
 
     const main = document.createElement('div');
     main.className = 'service-main';

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1793,7 +1793,7 @@ main {
 .service-item:hover {
   transform: translateY(-2px);
 }
-.service-item:focus-visible {
+.service-item:focus-within {
   outline: 2px solid var(--heading);
   outline-offset: 2px;
 }

--- a/audits/styles/components/service-item.css
+++ b/audits/styles/components/service-item.css
@@ -9,7 +9,7 @@
     .service-item:hover {
       transform: translateY(-2px);
     }
-    .service-item:focus-visible {
+    .service-item:focus-within {
       outline: 2px solid var(--heading);
       outline-offset: 2px;
     }


### PR DESCRIPTION
## Summary
- enable keyboard focus on active service items
- outline service items on focus to mirror Docker card behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08ee929dc832d95ba6c9070f86cc2