### PR TITLE
Emphasize host name in top bar

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1442,7 +1442,10 @@ main {
 }
 .brand-host {
   margin: 0;
-  font-size: var(--font-md);
+  font-size: var(--font-lg);
+  font-weight: 700;
+  color: var(--heading);
+  text-align: center;
   opacity: 0.7;
 }
 .brand-meta {

--- a/audits/styles/components/top-bar.css
+++ b/audits/styles/components/top-bar.css
@@ -32,7 +32,10 @@
 
     .brand-host {
       margin: 0;
-      font-size: var(--font-md);
+      font-size: var(--font-lg);
+      font-weight: 700;
+      color: var(--heading);
+      text-align: center;
       opacity: 0.7;
     }
 


### PR DESCRIPTION
## Summary
- Boost host name prominence by increasing font size, bold weight, and heading color in top bar
- Regenerate bundled styles to include new host styling

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8542c0c832d950c09d8ee225e3b