### PR TITLE
refactor: move top bar metadata

### DIFF
--- a/audits/index.html
+++ b/audits/index.html
@@ -23,17 +23,17 @@
         <span class="brand-title">Audit Serveur DW</span>
       </div>
       <p id="hostname" class="brand-host">-</p>
-      <div class="brand-meta">
-        <div class="meta-item">
-          <span class="meta-label">Généré le :</span>
-          <span id="generatedValue">--</span>
-          <span id="tzBadge" class="badge"></span>
-        </div>
-        <div class="meta-item">
-          <span class="meta-label">Uptime :</span>
-          <span id="uptimeValue">--</span>
-          <span id="uptimeSince"></span>
-        </div>
+    </div>
+    <div class="top-meta">
+      <div class="meta-item">
+        <span class="meta-label">Généré le :</span>
+        <span id="generatedValue">--</span>
+        <span id="tzBadge" class="badge"></span>
+      </div>
+      <div class="meta-item">
+        <span class="meta-label">Uptime :</span>
+        <span id="uptimeValue">--</span>
+        <span id="uptimeSince"></span>
       </div>
     </div>
     <div id="themeSwitchWrapper">

--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1415,7 +1415,7 @@ main {
   width: 100%;
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
   background: var(--block-bg);
   padding: 0.5rem 1rem;
@@ -1448,19 +1448,20 @@ main {
   text-align: center;
   opacity: 0.7;
 }
-.brand-meta {
+.top-meta {
+  justify-self: end;
+  text-align: right;
   display: flex;
   gap: var(--gap-3);
-  justify-content: center;
-  flex-wrap: wrap;
   font-size: var(--font-sm);
 }
-.brand-meta .meta-item {
+.top-meta .meta-item {
   display: flex;
   gap: var(--gap-1);
   align-items: center;
+  justify-content: flex-end;
 }
-.brand-meta .meta-label {
+.top-meta .meta-label {
   font-weight: 600;
 }
 .menu-toggle {
@@ -1552,7 +1553,7 @@ main {
 }
 @media (min-width: 900px) {
   .top-bar {
-    grid-template-columns: 44px 1fr auto;
+    grid-template-columns: 44px 1fr auto auto;
     padding-block: .4rem;
   }
   .top-brand {
@@ -1578,7 +1579,7 @@ main {
     margin: 0 var(--gap-2);
     opacity: .5;
   }
-  .brand-meta {
+  .top-meta {
     display: flex;
     gap: var(--gap-4);
     flex-wrap: nowrap;

--- a/audits/styles/components/top-bar.css
+++ b/audits/styles/components/top-bar.css
@@ -1,11 +1,11 @@
-    .top-bar {
+      .top-bar {
       position: sticky;
       top: 0;
       left: 0;
       width: 100%;
       box-sizing: border-box;
       display: grid;
-      grid-template-columns: auto 1fr auto;
+      grid-template-columns: auto 1fr auto auto;
       align-items: center;
       background: var(--block-bg);
       padding: 0.5rem 1rem;
@@ -39,21 +39,22 @@
       opacity: 0.7;
     }
 
-    .brand-meta {
+    .top-meta {
+      justify-self: end;
+      text-align: right;
       display: flex;
       gap: var(--gap-3);
-      justify-content: center;
-      flex-wrap: wrap;
       font-size: var(--font-sm);
     }
 
-    .brand-meta .meta-item {
+    .top-meta .meta-item {
       display: flex;
       gap: var(--gap-1);
       align-items: center;
+      justify-content: flex-end;
     }
 
-    .brand-meta .meta-label {
+    .top-meta .meta-label {
       font-weight: 600;
     }
 
@@ -146,7 +147,7 @@
   @media (min-width: 900px){
     /* grille du header + padding vertical plus serré */
     .top-bar{
-      grid-template-columns: 44px 1fr auto;  /* menu | brand | switch */
+      grid-template-columns: 44px 1fr auto auto;  /* menu | brand | meta | switch */
       padding-block: .4rem;
     }
 
@@ -179,7 +180,7 @@
     }
 
     /* "Généré / Uptime" sur une ligne pour éviter que le header regrossisse */
-    .brand-meta{
+    .top-meta{
       display: flex;
       gap: var(--gap-4);
       flex-wrap: nowrap;


### PR DESCRIPTION
## Summary
- move server metadata into new `.top-meta` container
- update top-bar grid and styles for new metadata block
- rebuild compiled CSS bundle

## Testing
- `./tests/run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0b984bfc0832dbf0b1c1a707be546