### PR TITLE
Restore metadata wrapping on narrow screens

### DIFF
--- a/audits/styles.css
+++ b/audits/styles.css
@@ -1453,6 +1453,7 @@ main {
   text-align: right;
   display: flex;
   gap: var(--gap-3);
+  flex-wrap: wrap;
   font-size: var(--font-sm);
 }
 .top-meta .meta-item {

--- a/audits/styles/components/top-bar.css
+++ b/audits/styles/components/top-bar.css
@@ -44,6 +44,7 @@
       text-align: right;
       display: flex;
       gap: var(--gap-3);
+      flex-wrap: wrap;
       font-size: var(--font-sm);
     }
 


### PR DESCRIPTION
## Summary
- allow `.top-meta` flex container to wrap on small viewports, preventing header overflow

## Testing
- `./tests/run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0bc3131e0832d915bb4c0bc2ff3eb